### PR TITLE
Fix deposit and support pre-execution gas estimation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ docs/
 
 # Dotenv file
 .env
+
+# MacOS
+**/.DS_Store

--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 **This repository contains all the necessary ingredients for successful cross-chain development utilizing the Analog General Message Passing protocol.**
 
-Foundry consists of:
-
-
-
 ## Dependencies
 
 This project uses **Forge** Ethereum testing framework (like Truffle, Hardhat and DappTools).

--- a/foundry.toml
+++ b/foundry.toml
@@ -10,14 +10,11 @@ deny_warnings = true
 # Solc options
 solc = '0.8.24'
 evm_version = 'shanghai'
-# evm_version = 'paris'
 optimizer = true
 optimizer_runs = 200000
 
 # EVM options
 gas_limit = 30000000
-# gas_limit = 3000000000
 gas_price = 1
 block_base_fee_per_gas = 0
 block_gas_limit = 30000000
-# block_gas_limit = 300000000000

--- a/foundry.toml
+++ b/foundry.toml
@@ -9,12 +9,15 @@ deny_warnings = true
 
 # Solc options
 solc = '0.8.24'
-evm_version = "shanghai"
+evm_version = 'shanghai'
+# evm_version = 'paris'
 optimizer = true
 optimizer_runs = 200000
 
 # EVM options
 gas_limit = 30000000
+# gas_limit = 3000000000
 gas_price = 1
 block_base_fee_per_gas = 0
 block_gas_limit = 30000000
+# block_gas_limit = 300000000000

--- a/src/Gateway.sol
+++ b/src/Gateway.sol
@@ -58,9 +58,6 @@ contract Gateway is IGateway, IExecutor, IUpgradable, GatewayEIP712 {
     uint8 internal constant SHARD_ACTIVE = (1 << 0); // Shard active bitflag
     uint8 internal constant SHARD_Y_PARITY = (1 << 1); // Pubkey y parity bitflag
 
-    // Measured gas cost difference for `execute` method
-    // uint256 internal constant EXECUTE_GAS_DIFF = 8536 + 10150;
-
     // Non-zero value used to initialize the `prevMessageHash` storage
     bytes32 internal constant FIRST_MESSAGE_PLACEHOLDER = bytes32(uint256(2 ** 256 - 1));
 
@@ -389,7 +386,7 @@ contract Gateway is IGateway, IExecutor, IUpgradable, GatewayEIP712 {
         _verifySignature(signature, messageHash);
 
         // Compute the GMP execution gas cost
-        (uint256 baseCost, uint256 executionCost) = GasUtils.txBaseCost(message.data.length);
+        (uint256 baseCost, uint256 executionCost) = GasUtils.executionGasCost(message.data.length);
         uint256 gasUsed = gasleft();
 
         // Check if the source has enough deposit and if the caller provided

--- a/src/Gateway.sol
+++ b/src/Gateway.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.8.0;
 
 import {Schnorr} from "@frost-evm/Schnorr.sol";
 import {BranchlessMath} from "./utils/BranchlessMath.sol";
-import {BytesUtils} from "./utils/BytesUtils.sol";
+import {GasUtils} from "./utils/GasUtils.sol";
 import {ERC1967} from "./utils/ERC1967.sol";
 import {IGateway} from "./interfaces/IGateway.sol";
 import {IUpgradable} from "./interfaces/IUpgradable.sol";
@@ -389,7 +389,7 @@ contract Gateway is IGateway, IExecutor, IUpgradable, GatewayEIP712 {
         _verifySignature(signature, messageHash);
 
         // Compute the GMP execution gas cost
-        (uint256 baseCost, uint256 executionCost) = BytesUtils.txBaseCost(message.data.length);
+        (uint256 baseCost, uint256 executionCost) = GasUtils.txBaseCost(message.data.length);
         uint256 gasUsed = gasleft();
 
         // Check if the source has enough deposit and if the caller provided

--- a/src/Gateway.sol
+++ b/src/Gateway.sol
@@ -5,6 +5,7 @@ pragma solidity >=0.8.0;
 
 import {Schnorr} from "@frost-evm/Schnorr.sol";
 import {BranchlessMath} from "./utils/BranchlessMath.sol";
+import {BytesUtils} from "./utils/BytesUtils.sol";
 import {IGateway} from "./interfaces/IGateway.sol";
 import {IUpgradable} from "./interfaces/IUpgradable.sol";
 import {IGmpReceiver} from "./interfaces/IGmpReceiver.sol";
@@ -51,12 +52,13 @@ contract Gateway is IGateway, IExecutor, IUpgradable, GatewayEIP712 {
     using PrimitiveUtils for UpdateKeysMessage;
     using PrimitiveUtils for GmpMessage;
     using PrimitiveUtils for address;
+    using BranchlessMath for uint256;
 
     uint8 internal constant SHARD_ACTIVE = (1 << 0); // Shard active bitflag
     uint8 internal constant SHARD_Y_PARITY = (1 << 1); // Pubkey y parity bitflag
 
     // Measured gas cost difference for `execute` method
-    uint256 internal constant EXECUTE_GAS_DIFF = 10_592;
+    uint256 internal constant EXECUTE_GAS_DIFF = 8536;
 
     // Non-zero value used to initialize the `prevMessageHash` storage
     bytes32 internal constant FIRST_MESSAGE_PLACEHOLDER = bytes32(uint256(2 ** 256 - 1));
@@ -95,10 +97,8 @@ contract Gateway is IGateway, IExecutor, IUpgradable, GatewayEIP712 {
      * reference: https://docs.soliditylang.org/en/latest/internals/layout_in_storage.html
      */
     struct GmpInfo {
-        uint184 _gap; // gap to keep status and blocknumber 256bit aligned
         GmpStatus status;
         uint64 blockNumber; // block in which the message was processed
-        bytes32 result; // the result of the GMP message
     }
 
     constructor(uint16 network, address proxy) payable GatewayEIP712(network, proxy) {}
@@ -136,153 +136,6 @@ contract Gateway is IGateway, IExecutor, IUpgradable, GatewayEIP712 {
 
     function networkId() external view returns (uint16) {
         return NETWORK_ID;
-    }
-
-    // Best-effort attempt at estimating the base gas use of the transaction.
-    // This includes:
-    // * Cost paid for every transaction: 21000 gas
-    // * Cost of calldata: Zero byte = 4 gas, Non-zero byte = 16 gas
-    // * Cost of code inside submitInitial that is not metered: 14_698
-    //
-    // Reference: Ethereum Yellow Paper
-    function _transactionBaseGas() internal pure returns (uint256 result) {
-        /// @solidity memory-safe-assembly
-        assembly {
-            let mask := 0x0101010101010101010101010101010101010101010101010101010101010101
-            // 1
-            let ptr := 0
-            let v := calldataload(0)
-            v := or(v, shr(4, v))
-            v := or(v, shr(2, v))
-            v := or(v, shr(1, v))
-            v := and(v, mask)
-            {
-                // 2
-                ptr := add(ptr, 32)
-                let r := calldataload(ptr)
-                r := or(r, shr(4, r))
-                r := or(r, shr(2, r))
-                r := or(r, shr(1, r))
-                r := and(r, mask)
-                v := add(v, r)
-                // 3
-                ptr := add(ptr, 32)
-                r := calldataload(ptr)
-                r := or(r, shr(4, r))
-                r := or(r, shr(2, r))
-                r := or(r, shr(1, r))
-                r := and(r, mask)
-                v := add(v, r)
-                // 4
-                ptr := add(ptr, 32)
-                r := calldataload(ptr)
-                r := or(r, shr(4, r))
-                r := or(r, shr(2, r))
-                r := or(r, shr(1, r))
-                r := and(r, mask)
-                v := add(v, r)
-                // 5
-                ptr := add(ptr, 32)
-                r := calldataload(ptr)
-                r := or(r, shr(4, r))
-                r := or(r, shr(2, r))
-                r := or(r, shr(1, r))
-                r := and(r, mask)
-                v := add(v, r)
-                // 6
-                ptr := add(ptr, 32)
-                r := calldataload(ptr)
-                r := or(r, shr(4, r))
-                r := or(r, shr(2, r))
-                r := or(r, shr(1, r))
-                r := and(r, mask)
-                v := add(v, r)
-                // 7
-                ptr := add(ptr, 32)
-                r := calldataload(ptr)
-                r := or(r, shr(4, r))
-                r := or(r, shr(2, r))
-                r := or(r, shr(1, r))
-                r := and(r, mask)
-                v := add(v, r)
-                // 8
-                ptr := add(ptr, 32)
-                r := calldataload(ptr)
-                r := or(r, shr(4, r))
-                r := or(r, shr(2, r))
-                r := or(r, shr(1, r))
-                r := and(r, mask)
-                v := add(v, r)
-                // 9
-                ptr := add(ptr, 32)
-                r := calldataload(ptr)
-                r := or(r, shr(4, r))
-                r := or(r, shr(2, r))
-                r := or(r, shr(1, r))
-                r := and(r, mask)
-                v := add(v, r)
-                // 10
-                ptr := add(ptr, 32)
-                r := calldataload(ptr)
-                r := or(r, shr(4, r))
-                r := or(r, shr(2, r))
-                r := or(r, shr(1, r))
-                r := and(r, mask)
-                v := add(v, r)
-                // 11
-                ptr := add(ptr, 32)
-                r := calldataload(ptr)
-                r := or(r, shr(4, r))
-                r := or(r, shr(2, r))
-                r := or(r, shr(1, r))
-                r := and(r, mask)
-                v := add(v, r)
-                // 12
-                ptr := add(ptr, 32)
-                r := calldataload(ptr)
-                r := or(r, shr(4, r))
-                r := or(r, shr(2, r))
-                r := or(r, shr(1, r))
-                r := and(r, mask)
-                v := add(v, r)
-                // 13
-                ptr := add(ptr, 32)
-                r := calldataload(ptr)
-                r := or(r, shr(4, r))
-                r := or(r, shr(2, r))
-                r := or(r, shr(1, r))
-                r := and(r, mask)
-                v := add(v, r)
-                // 14
-                ptr := add(ptr, 32)
-                r := calldataload(ptr)
-                r := or(r, shr(4, r))
-                r := or(r, shr(2, r))
-                r := or(r, shr(1, r))
-                r := and(r, mask)
-                v := add(v, r)
-                // 15
-                ptr := add(ptr, 32)
-                r := calldataload(ptr)
-                r := or(r, shr(4, r))
-                r := or(r, shr(2, r))
-                r := or(r, shr(1, r))
-                r := and(r, mask)
-                v := add(v, r)
-            }
-
-            // Count bytes in parallel
-            v := add(v, shr(128, v))
-            v := add(v, shr(64, v))
-            v := add(v, shr(32, v))
-            v := add(v, shr(16, v))
-            v := and(v, 0xffff)
-            v := add(and(v, 0xff), shr(8, v))
-
-            result := add(21000, add(mul(sub(calldatasize(), v), 4), mul(v, 16)))
-            let words := shr(5, add(calldatasize(), 31))
-            result := add(result, add(shr(9, mul(words, words)), mul(words, 3)))
-        }
     }
 
     /**
@@ -429,6 +282,26 @@ contract Gateway is IGateway, IExecutor, IUpgradable, GatewayEIP712 {
         _deposits[source][network] += msg.value;
     }
 
+    function _gmpInsufficientFunds(bytes32 payloadHash, GmpMessage calldata message)
+        private
+        returns (GmpStatus status, bytes32 result)
+    {
+        // Verify if this GMP message was already executed
+        GmpInfo storage gmp = _messages[payloadHash];
+        require(gmp.status == GmpStatus.NOT_FOUND, "message already executed");
+
+        // Set status and result
+        status = GmpStatus.INSUFFICIENT_FUNDS;
+        result = bytes32(0);
+
+        // Store gmp execution status on storage
+        gmp.status = status;
+        gmp.blockNumber = uint64(block.number);
+
+        // Emit event
+        emit GmpExecuted(payloadHash, message.source, message.dest, status, result);
+    }
+
     // Execute GMP message
     function _execute(bytes32 payloadHash, GmpMessage calldata message, bytes memory data)
         private
@@ -442,25 +315,24 @@ contract Gateway is IGateway, IExecutor, IUpgradable, GatewayEIP712 {
         gmp.status = GmpStatus.PENDING;
         gmp.blockNumber = uint64(block.number);
 
-        // Execute GMP call
-        bytes32[1] memory output = [bytes32(0)];
-        bool success;
-        address dest = message.dest;
-
         // Cap the GMP gas limit to 80% of the block gas limit
         // OBS: we assume the remaining 20% is enough for the Gateway execution, which is a safe assumption
         // once most EVM blockchains have gas limits above 10M and don't need more than 60k gas for the Gateway execution.
-        uint256 maxGasLimit = (block.gaslimit / 5) * 4; // 80% of the block gas limit
+        uint256 maxGasLimit = block.gaslimit.saturatingMul(4).saturatingDiv(5); // 80% of the block gas limit
         uint256 gasLimit = BranchlessMath.min(message.gasLimit, maxGasLimit);
 
         // Make sure the gas left is enough to execute the GMP message
-        unchecked {
-            // Subtract 5000 gas, 2600 (CALL) + 2400 (other instructions with some margin)
-            uint256 gasAvailable = BranchlessMath.saturatingSub(gasleft(), 5000);
-            // “all but one 64th", reference: https://eips.ethereum.org/EIPS/eip-150
-            gasAvailable -= gasAvailable >> 6;
-            require(gasAvailable > gasLimit, "gas left below message.gasLimit");
-        }
+        // unchecked {
+        //     // Subtract 5000 gas, 2600 (CALL) + 2400 (other instructions with some margin)
+        //     uint256 gasAvailable = BranchlessMath.saturatingSub(gasleft(), 10000);
+        //     // “all but one 64th", reference: https://eips.ethereum.org/EIPS/eip-150
+        //     gasAvailable -= gasAvailable >> 6;
+        //     require(gasAvailable > gasLimit, "gas left below message.gasLimit");
+        // }
+
+        // Execute GMP call
+        bool success;
+        address dest = message.dest;
 
         /// @solidity memory-safe-assembly
         assembly {
@@ -468,6 +340,7 @@ contract Gateway is IGateway, IExecutor, IUpgradable, GatewayEIP712 {
             // regardless if the call reverts or not.
             let ptr := add(data, 32)
             let size := mload(data)
+            mstore(data, 0)
 
             // returns 1 if the call succeed, and 0 if it reverted
             success :=
@@ -477,19 +350,19 @@ contract Gateway is IGateway, IExecutor, IUpgradable, GatewayEIP712 {
                     0, // value in wei to transfer (always zero for GMP)
                     ptr, // input memory pointer
                     size, // input size
-                    output, // output memory pointer
+                    data, // output memory pointer
                     32 // output size (fixed 32 bytes)
                 )
-        }
 
-        // Get Result
-        result = output[0];
+            // Get Result, reuse data to keep a predictable memory expansion
+            result := mload(data)
+            mstore(data, size)
+        }
 
         // Update GMP status
         status = GmpStatus(BranchlessMath.select(success, uint256(GmpStatus.SUCCESS), uint256(GmpStatus.REVERT)));
 
-        // Persist result and status on storage
-        gmp.result = result;
+        // Persist gmp execution status on storage
         gmp.status = status;
 
         // Emit event
@@ -505,25 +378,53 @@ contract Gateway is IGateway, IExecutor, IUpgradable, GatewayEIP712 {
         external
         returns (GmpStatus status, bytes32 result)
     {
-        uint256 startGas = gasleft();
-
         // Theoretically we could remove the destination network field
         // and fill it up with the network id of the contract, then the signature will fail.
         require(message.destNetwork == NETWORK_ID, "invalid gmp network");
         require(_networks[message.srcNetwork] != bytes32(0), "source network no supported");
 
+        // Verify the signature
         (bytes32 messageHash, bytes memory data) = message.encodeCallback(DOMAIN_SEPARATOR);
         _verifySignature(signature, messageHash);
-        (status, result) = _execute(messageHash, message, data);
+
+        // Compute the GMP execution gas cost
+        (uint256 baseCost, uint256 executionCost) = BytesUtils.txBaseCost(message.data.length);
+        uint256 gasUsed = gasleft();
+
+        // Check if the source has enough deposit and if the caller provided
+        // enough gas to execute the GMP message
         uint256 deposited = _deposits[message.source][message.srcNetwork];
+        unchecked {
+            // Cap the GMP gas limit to 50% of the block gas limit
+            uint256 gasLimit = block.gaslimit >> 1; // 50% of the block gas limit
+            gasLimit = BranchlessMath.min(message.gasLimit, gasLimit);
+
+            // Check if the source has enough deposit before executing the GMP message
+            uint256 gasRequired = executionCost.saturatingAdd(gasLimit);
+            uint256 minDeposit = gasRequired.saturatingAdd(baseCost).saturatingMul(tx.gasprice);
+            if (deposited < minDeposit) {
+                return _gmpInsufficientFunds(messageHash, message);
+            }
+
+            // Check if the relayer provided enough gas to execute the GMP message
+            uint256 minGasLeft = gasLimit.saturatingAdd(39190);
+            require(gasUsed >= minGasLeft, "insufficient gas to execute GMP message");
+
+            // Add base cost to the gas used
+            gasUsed = gasUsed.saturatingAdd(baseCost);
+        }
+
+        (status, result) = _execute(messageHash, message, data);
 
         // Calculate a gas refund, capped to protect against huge spikes in `tx.gasprice`
         // that could drain funds unnecessarily. During these spikes, relayers should back off.
-        uint256 gasUsed = _transactionBaseGas() + (startGas - gasleft()) + EXECUTE_GAS_DIFF;
-        uint256 refund = gasUsed * tx.gasprice;
-        require(deposited >= refund, "deposit below max refund");
-        _deposits[message.source][message.srcNetwork] = deposited - refund;
-        payable(msg.sender).transfer(refund);
+        unchecked {
+            gasUsed -= gasleft();
+            gasUsed += EXECUTE_GAS_DIFF;
+            uint256 refund = BranchlessMath.min(gasUsed * tx.gasprice, deposited);
+            _deposits[message.source][message.srcNetwork] -= refund;
+            payable(msg.sender).transfer(refund);
+        }
     }
 
     /**

--- a/src/Gateway.sol
+++ b/src/Gateway.sol
@@ -56,7 +56,7 @@ contract Gateway is IGateway, IExecutor, IUpgradable, GatewayEIP712 {
     uint8 internal constant SHARD_Y_PARITY = (1 << 1); // Pubkey y parity bitflag
 
     // Measured gas cost difference for `execute` method
-    uint256 internal constant EXECUTE_GAS_DIFF = 10_584;
+    uint256 internal constant EXECUTE_GAS_DIFF = 10_592;
 
     // Non-zero value used to initialize the `prevMessageHash` storage
     bytes32 internal constant FIRST_MESSAGE_PLACEHOLDER = bytes32(uint256(2 ** 256 - 1));

--- a/src/GatewayProxy.sol
+++ b/src/GatewayProxy.sol
@@ -22,8 +22,11 @@ library ERC1967 {
 }
 
 contract GatewayProxy {
+    /**
+     * @dev Minimal EIP-1967 proxy bytecode.
+     */
     bytes private constant PROXY_BYTECODE =
-        hex"365f5f375f5f365f7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc545af43d5f5f3e6036573d5ffd5b3d5ff3";
+        hex"363d3d373d3d3d363d7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc545af43d82803e903d91603857fd5bf3";
 
     constructor(address implementation, bytes memory initializer) payable {
         require(implementation.code.length > 0, "not a contract");

--- a/src/GatewayProxy.sol
+++ b/src/GatewayProxy.sol
@@ -3,23 +3,7 @@
 
 pragma solidity >=0.8.0;
 
-/// @title Minimal implementation of ERC1967 storage slot
-library ERC1967 {
-    // bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1)
-    bytes32 internal constant _IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
-
-    function load() internal view returns (address implementation) {
-        assembly {
-            implementation := sload(_IMPLEMENTATION_SLOT)
-        }
-    }
-
-    function store(address implementation) internal {
-        assembly {
-            sstore(_IMPLEMENTATION_SLOT, implementation)
-        }
-    }
-}
+import {ERC1967} from "./utils/ERC1967.sol";
 
 contract GatewayProxy {
     /**

--- a/src/Primitives.sol
+++ b/src/Primitives.sol
@@ -81,6 +81,7 @@ enum GmpStatus {
     NOT_FOUND,
     SUCCESS,
     REVERT,
+    INSUFFICIENT_FUNDS,
     PENDING
 }
 

--- a/src/interfaces/IExecutor.sol
+++ b/src/interfaces/IExecutor.sol
@@ -34,7 +34,7 @@ interface IExecutor {
      * @param signature Schnorr signature
      * @param message GMP message
      */
-    function execute(Signature memory signature, GmpMessage memory message)
+    function execute(Signature calldata signature, GmpMessage calldata message)
         external
         returns (GmpStatus status, bytes32 result);
 

--- a/src/utils/BranchlessMath.sol
+++ b/src/utils/BranchlessMath.sol
@@ -65,20 +65,35 @@ library BranchlessMath {
      * @dev Unsigned saturating subtraction, bounds to zero instead of overflowing.
      * equivalent to: x > y ? x - y : 0
      */
-    function saturatingSub(uint256 x, uint256 y) internal pure returns (uint256) {
+    function saturatingSub(uint256 a, uint256 b) internal pure returns (uint256) {
         unchecked {
-            return (x - y) * toUint(x > y);
+            // equivalent to: a > b ? a - b : 0
+            return (a - b) * toUint(a > b);
         }
     }
 
     /**
-     * @dev Unsigned saturating multiplication, bounds to UINT256 MAX instead of overflowing.
+     * @dev Unsigned saturating multiplication, bounds to `2 ** 256 - 1` instead of overflowing.
      */
-    function saturatingMul(uint256 x, uint256 y) internal pure returns (uint256) {
+    function saturatingMul(uint256 a, uint256 b) internal pure returns (uint256) {
         unchecked {
-            x = x * y;
-            y = 0 - toUint((x / y) != y);
-            return x | y;
+            uint256 c = a * b;
+            bool success;
+            assembly {
+                // Only true when the multiplication doesn't overflow
+                // (c / a == b) || (a == 0)
+                success := or(eq(div(c, a), b), iszero(a))
+            }
+            return c | (toUint(success) - 1);
+        }
+    }
+
+    /**
+     * @dev Unsigned saturating division, bounds to UINT256 MAX instead of overflowing.
+     */
+    function saturatingDiv(uint256 x, uint256 y) internal pure returns (uint256 r) {
+        assembly {
+            r := div(x, y)
         }
     }
 

--- a/src/utils/BytesUtils.sol
+++ b/src/utils/BytesUtils.sol
@@ -7,7 +7,7 @@ pragma solidity ^0.8.20;
  * @dev Utilities for branchless operations, useful when a constant gas cost is required.
  */
 library BytesUtils {
-    uint256 internal constant EXECUTION_BASE_COST = 43_354;
+    uint256 internal constant EXECUTION_BASE_COST = 43_376;
 
     /**
      * @dev Compute the transaction base cost.

--- a/src/utils/BytesUtils.sol
+++ b/src/utils/BytesUtils.sol
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: MIT
+// Analog's Contracts (last updated v0.1.0) (src/utils/BytesUtils.sol)
+
+pragma solidity ^0.8.20;
+
+/**
+ * @dev Utilities for branchless operations, useful when a constant gas cost is required.
+ */
+library BytesUtils {
+    uint256 internal constant EXECUTION_BASE_COST = 43_354;
+
+    /**
+     * @dev Compute the transaction base cost.
+     */
+    function txBaseCost(uint256 messageSize) internal pure returns (uint256 baseCost, uint256 executionCost) {
+        // Calculate Gateway.execute dynamic cost
+        executionCost = EXECUTION_BASE_COST;
+        unchecked {
+            // calldatacopy (3 gas per word)
+            uint256 words = (messageSize + 31) >> 5;
+            executionCost += words * 3;
+
+            // keccak256 (6 gas per word)
+            executionCost += words * 6;
+
+            // Memory expansion cost
+            words = 0xa4 + (words << 5); // onGmpReceived encoded call size
+            words = (words + 31) & 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0;
+            words += 0x0200; // Memory size
+            words = (words + 31) >> 5; // to words
+            executionCost += ((words * words) / 512) + (words * 3);
+
+            // Calculate Proxy memory expansion cost
+            // Proxy execute(selector + signature + gmpData)
+            words = 388 + ((messageSize + 31) & 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0);
+            words = (words + 31) >> 5;
+            executionCost += ((words * words) / 512) + (words * 6);
+
+            // Base Cost calculation
+            executionCost += ((words - 1) / 15) * 1845;
+        }
+
+        // Efficient algorithm for counting non-zero calldata bytes in chunks of 480 bytes at time
+        // computation gas cost = 1845 * ceil(msg.data.length / 480) + 61
+        assembly {
+            {
+                baseCost := 0
+                for {
+                    let ptr := 0
+                    let mask := 0x0101010101010101010101010101010101010101010101010101010101010101
+                } lt(ptr, calldatasize()) { ptr := add(ptr, 32) } {
+                    // 1
+                    let v := calldataload(ptr)
+                    v := or(v, shr(4, v))
+                    v := or(v, shr(2, v))
+                    v := or(v, shr(1, v))
+                    v := and(v, mask)
+                    {
+                        // 2
+                        ptr := add(ptr, 32)
+                        let r := calldataload(ptr)
+                        r := or(r, shr(4, r))
+                        r := or(r, shr(2, r))
+                        r := or(r, shr(1, r))
+                        r := and(r, mask)
+                        v := add(v, r)
+                        // 3
+                        ptr := add(ptr, 32)
+                        r := calldataload(ptr)
+                        r := or(r, shr(4, r))
+                        r := or(r, shr(2, r))
+                        r := or(r, shr(1, r))
+                        r := and(r, mask)
+                        v := add(v, r)
+                        // 4
+                        ptr := add(ptr, 32)
+                        r := calldataload(ptr)
+                        r := or(r, shr(4, r))
+                        r := or(r, shr(2, r))
+                        r := or(r, shr(1, r))
+                        r := and(r, mask)
+                        v := add(v, r)
+                        // 5
+                        ptr := add(ptr, 32)
+                        r := calldataload(ptr)
+                        r := or(r, shr(4, r))
+                        r := or(r, shr(2, r))
+                        r := or(r, shr(1, r))
+                        r := and(r, mask)
+                        v := add(v, r)
+                        // 6
+                        ptr := add(ptr, 32)
+                        r := calldataload(ptr)
+                        r := or(r, shr(4, r))
+                        r := or(r, shr(2, r))
+                        r := or(r, shr(1, r))
+                        r := and(r, mask)
+                        v := add(v, r)
+                        // 7
+                        ptr := add(ptr, 32)
+                        r := calldataload(ptr)
+                        r := or(r, shr(4, r))
+                        r := or(r, shr(2, r))
+                        r := or(r, shr(1, r))
+                        r := and(r, mask)
+                        v := add(v, r)
+                        // 8
+                        ptr := add(ptr, 32)
+                        r := calldataload(ptr)
+                        r := or(r, shr(4, r))
+                        r := or(r, shr(2, r))
+                        r := or(r, shr(1, r))
+                        r := and(r, mask)
+                        v := add(v, r)
+                        // 9
+                        ptr := add(ptr, 32)
+                        r := calldataload(ptr)
+                        r := or(r, shr(4, r))
+                        r := or(r, shr(2, r))
+                        r := or(r, shr(1, r))
+                        r := and(r, mask)
+                        v := add(v, r)
+                        // 10
+                        ptr := add(ptr, 32)
+                        r := calldataload(ptr)
+                        r := or(r, shr(4, r))
+                        r := or(r, shr(2, r))
+                        r := or(r, shr(1, r))
+                        r := and(r, mask)
+                        v := add(v, r)
+                        // 11
+                        ptr := add(ptr, 32)
+                        r := calldataload(ptr)
+                        r := or(r, shr(4, r))
+                        r := or(r, shr(2, r))
+                        r := or(r, shr(1, r))
+                        r := and(r, mask)
+                        v := add(v, r)
+                        // 12
+                        ptr := add(ptr, 32)
+                        r := calldataload(ptr)
+                        r := or(r, shr(4, r))
+                        r := or(r, shr(2, r))
+                        r := or(r, shr(1, r))
+                        r := and(r, mask)
+                        v := add(v, r)
+                        // 13
+                        ptr := add(ptr, 32)
+                        r := calldataload(ptr)
+                        r := or(r, shr(4, r))
+                        r := or(r, shr(2, r))
+                        r := or(r, shr(1, r))
+                        r := and(r, mask)
+                        v := add(v, r)
+                        // 14
+                        ptr := add(ptr, 32)
+                        r := calldataload(ptr)
+                        r := or(r, shr(4, r))
+                        r := or(r, shr(2, r))
+                        r := or(r, shr(1, r))
+                        r := and(r, mask)
+                        v := add(v, r)
+                        // 15
+                        ptr := add(ptr, 32)
+                        r := calldataload(ptr)
+                        r := or(r, shr(4, r))
+                        r := or(r, shr(2, r))
+                        r := or(r, shr(1, r))
+                        r := and(r, mask)
+                        v := add(v, r)
+                    }
+
+                    // Count bytes in parallel
+                    v := add(v, shr(128, v))
+                    v := add(v, shr(64, v))
+                    v := add(v, shr(32, v))
+                    v := add(v, shr(16, v))
+                    v := and(v, 0xffff)
+                    v := add(and(v, 0xff), shr(8, v))
+                    baseCost := add(baseCost, v)
+                }
+                baseCost := add(21000, add(mul(sub(calldatasize(), baseCost), 4), mul(baseCost, 16)))
+            }
+        }
+    }
+}

--- a/src/utils/BytesUtils.sol
+++ b/src/utils/BytesUtils.sol
@@ -7,7 +7,7 @@ pragma solidity ^0.8.20;
  * @dev Utilities for branchless operations, useful when a constant gas cost is required.
  */
 library BytesUtils {
-    uint256 internal constant EXECUTION_BASE_COST = 43_376;
+    uint256 internal constant EXECUTION_BASE_COST = 43_303 + 4500;
 
     /**
      * @dev Compute the transaction base cost.

--- a/src/utils/ERC1967.sol
+++ b/src/utils/ERC1967.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+// Analog's Contracts (last updated v0.1.0) (src/utils/ERC1967.sol)
+
+pragma solidity >=0.8.0;
+
+/// @title Minimal implementation of ERC1967 storage slot
+library ERC1967 {
+    // bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1)
+    bytes32 internal constant _IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
+    function load() internal view returns (address implementation) {
+        assembly {
+            implementation := sload(_IMPLEMENTATION_SLOT)
+        }
+    }
+
+    function store(address implementation) internal {
+        assembly {
+            sstore(_IMPLEMENTATION_SLOT, implementation)
+        }
+    }
+}

--- a/src/utils/GasUtils.sol
+++ b/src/utils/GasUtils.sol
@@ -12,7 +12,7 @@ library GasUtils {
     /**
      * @dev Compute the transaction base cost.
      */
-    function txBaseCost(uint256 messageSize) internal pure returns (uint256 baseCost, uint256 executionCost) {
+    function executionGasCost(uint256 messageSize) internal pure returns (uint256 baseCost, uint256 executionCost) {
         // Calculate Gateway.execute dynamic cost
         executionCost = EXECUTION_BASE_COST;
         unchecked {

--- a/src/utils/GasUtils.sol
+++ b/src/utils/GasUtils.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
-// Analog's Contracts (last updated v0.1.0) (src/utils/BytesUtils.sol)
+// Analog's Contracts (last updated v0.1.0) (src/utils/GasUtils.sol)
 
 pragma solidity ^0.8.20;
 
 /**
  * @dev Utilities for branchless operations, useful when a constant gas cost is required.
  */
-library BytesUtils {
+library GasUtils {
     uint256 internal constant EXECUTION_BASE_COST = 43_303 + 4500;
 
     /**

--- a/test/Gateway.t.sol
+++ b/test/Gateway.t.sol
@@ -99,7 +99,7 @@ library GatewayUtils {
         pure
         returns (uint256 baseCost, uint256 executionCost)
     {
-        (, executionCost) = GasUtils.txBaseCost(message.data.length);
+        (, executionCost) = GasUtils.executionGasCost(message.data.length);
         bytes memory encodedCall = abi.encodeCall(IExecutor.execute, (signature, message));
         baseCost = TestUtils.calculateBaseCost(encodedCall);
     }
@@ -150,8 +150,6 @@ contract GatewayBase is Test {
         // Obs: This is a special contract that wastes an exact amount of gas you send to it, helpful for testing GMP refunds and gas limits.
         // See the file `HelperContract.opcode` for more details.
         {
-            // bytes memory bytecode =
-            //    hex"603b80600c6000396000f3fe60a4355a5b6000828203126004570360080180603b015b805a11601657505a03604b03565b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b00";
             bytes memory bytecode =
                 hex"603b80600c6000396000f3fe5a600201803d523d60209160643560240135146018575bfd5b60345a116018575a604803565b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5bf3";
             receiver = IGmpReceiver(TestUtils.deployContract(bytecode));

--- a/test/Gateway.t.sol
+++ b/test/Gateway.t.sol
@@ -9,7 +9,7 @@ import {VmSafe} from "forge-std/Vm.sol";
 import {TestUtils} from "./TestUtils.sol";
 import {Gateway, GatewayEIP712} from "../src/Gateway.sol";
 import {GatewayProxy} from "../src/GatewayProxy.sol";
-import {BytesUtils} from "../src/utils/BytesUtils.sol";
+import {GasUtils} from "../src/utils/GasUtils.sol";
 import {BranchlessMath} from "../src/utils/BranchlessMath.sol";
 import {IGateway} from "../src/interfaces/IGateway.sol";
 import {IGmpReceiver} from "../src/interfaces/IGmpReceiver.sol";
@@ -99,7 +99,7 @@ library GatewayUtils {
         pure
         returns (uint256 baseCost, uint256 executionCost)
     {
-        (, executionCost) = BytesUtils.txBaseCost(message.data.length);
+        (, executionCost) = GasUtils.txBaseCost(message.data.length);
         bytes memory encodedCall = abi.encodeCall(IExecutor.execute, (signature, message));
         baseCost = TestUtils.calculateBaseCost(encodedCall);
     }

--- a/test/Gateway.t.sol
+++ b/test/Gateway.t.sol
@@ -65,7 +65,6 @@ library GatewayUtils {
         internal
         returns (GmpStatus status, bytes32 result)
     {
-        require(ctx.gasLimit >= message.gasLimit, "GatewayUtils: gas left below message.gasLimit");
         bytes memory encodedCall = abi.encodeCall(IExecutor.execute, (signature, message));
         (uint256 executionCost, uint256 baseCost, bytes memory output) =
             TestUtils.executeCall(ctx.from, ctx.to, ctx.gasLimit, encodedCall);
@@ -120,8 +119,7 @@ contract GatewayBase is Test {
     // Receiver Contract, the will waste the exact amount of gas you sent to it in the data field
     IGmpReceiver internal receiver;
 
-    uint256 private constant EXECUTE_CALL_COST = 49_711;
-    uint256 private constant SUBMIT_GAS_COST = 6001;
+    uint256 private constant SUBMIT_GAS_COST = 6053;
     uint16 private constant SRC_NETWORK_ID = 1234;
     uint16 internal constant DEST_NETWORK_ID = 1337;
     uint8 private constant GMP_STATUS_SUCCESS = 1;
@@ -152,8 +150,10 @@ contract GatewayBase is Test {
         // Obs: This is a special contract that wastes an exact amount of gas you send to it, helpful for testing GMP refunds and gas limits.
         // See the file `HelperContract.opcode` for more details.
         {
+            // bytes memory bytecode =
+            //    hex"603b80600c6000396000f3fe60a4355a5b6000828203126004570360080180603b015b805a11601657505a03604b03565b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b00";
             bytes memory bytecode =
-                hex"603b80600c6000396000f3fe60a4355a5b6000828203126004570360080180603b015b805a11601657505a03604b03565b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b00";
+                hex"603b80600c6000396000f3fe5a600201803d523d60209160643560240135146018575bfd5b60345a116018575a604803565b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5bf3";
             receiver = IGmpReceiver(TestUtils.deployContract(bytecode));
         }
     }
@@ -164,14 +164,14 @@ contract GatewayBase is Test {
         return Signature({xCoord: signer.xCoord(), e: e, s: s});
     }
 
-    function testDepositRevertsOutOfFunds() external {
+    function test_DepositRevertsOutOfFunds() external {
         address sender = TestUtils.createTestAccount(0);
         vm.prank(sender, sender);
         vm.expectRevert();
         gateway.deposit{value: 1}(sender.toSender(false), 0);
     }
 
-    function testDepositReducesSenderFunds() public {
+    function test_DepositReducesSenderFunds() public {
         uint256 amount = 100 ether;
         address sender = TestUtils.createTestAccount(amount);
         uint256 balanceBefore = address(sender).balance;
@@ -182,7 +182,7 @@ contract GatewayBase is Test {
         assertEq(balanceAfter, expectedBalance, "deposit failed to transfer amount from sender");
     }
 
-    function testDepositIncreasesGatewayFunds() external {
+    function test_DepositIncreasesGatewayFunds() external {
         uint256 amount = 100 ether;
         address sender = TestUtils.createTestAccount(amount);
         address gatewayAddress = address(gateway);
@@ -195,7 +195,7 @@ contract GatewayBase is Test {
         assertEq(balanceAfter, expectedBalance, "deposit failed to transfer amount to gateway");
     }
 
-    function testReceiver() external {
+    function test_Receiver() external {
         bytes memory testEncodedCall = abi.encodeCall(
             IGmpReceiver.onGmpReceived,
             (
@@ -208,9 +208,9 @@ contract GatewayBase is Test {
         // Calling the receiver contract directly to make the address warm
         address sender = TestUtils.createTestAccount(10 ether);
         (uint256 gasUsed,, bytes memory output) =
-            TestUtils.executeCall(sender, address(receiver), 100_000, testEncodedCall);
+            TestUtils.executeCall(sender, address(receiver), 23_318, testEncodedCall);
         assertEq(gasUsed, 1234);
-        assertEq(output.length, 0);
+        assertEq(output.length, 32);
     }
 
     function test_gasMeter() external {
@@ -246,7 +246,7 @@ contract GatewayBase is Test {
             from: sender,
             to: address(gateway),
             value: 0,
-            gasLimit: baseCost + executionCost + 4500 + 2160 + 694,
+            gasLimit: baseCost + executionCost + 2160 + 693,
             executionCost: 0,
             baseCost: 0
         });
@@ -263,10 +263,10 @@ contract GatewayBase is Test {
 
         // Execute GMP message first time (which have 4500 gas overhead)
         (status, returned) = ctx.execute(sig, gmp);
-        assertEq(executionCost + 4500, ctx.executionCost, "executionCost + 4500 != ctx.executionCost");
+        assertEq(returned, bytes32(0), "GMP result stored doesn't match the returned result");
+        assertEq(executionCost, ctx.executionCost, "executionCost != ctx.executionCost");
         assertEq(baseCost, ctx.baseCost, "baseCost != ctx.baseCost");
         assertEq(uint256(status), uint256(GmpStatus.SUCCESS), "Unexpected GMP status");
-        assertEq(returned, bytes32(0), "GMP result stored doesn't match the returned result");
     }
 
     function test_depositMapping() external {
@@ -274,9 +274,7 @@ contract GatewayBase is Test {
         address sender = TestUtils.createTestAccount(100 ether);
 
         // GMP message gas used
-        uint256 gmpGasUsed = 1_000;
-        (, uint256 expectGasUsed) = BytesUtils.txBaseCost(32);
-        expectGasUsed += gmpGasUsed + 4500;
+        uint256 gmpGasLimit = 1_000;
 
         // Build and sign GMP message
         GmpMessage memory gmp = GmpMessage({
@@ -284,105 +282,104 @@ contract GatewayBase is Test {
             srcNetwork: SRC_NETWORK_ID,
             dest: address(receiver),
             destNetwork: DEST_NETWORK_ID,
-            gasLimit: gmpGasUsed + 8,
+            gasLimit: gmpGasLimit,
             salt: 1,
-            data: abi.encodePacked(gmpGasUsed)
+            data: abi.encodePacked(gmpGasLimit)
         });
         Signature memory sig = sign(gmp);
-
-        // Calculate memory expansion cost and base cost
-        uint256 baseCost;
-        {
-            bytes memory encodedExecuteCall = abi.encodeCall(IExecutor.execute, (sig, gmp));
-            baseCost = TestUtils.calculateBaseCost(encodedExecuteCall);
-        }
+        (uint256 baseCost, uint256 executionCost) = GatewayUtils.computeGmpGasCost(sig, gmp);
 
         // Deposit funds
         {
             GmpSender gmpSender = sender.toSender(false);
             assertEq(gateway.depositOf(gmpSender, SRC_NETWORK_ID), 0);
             vm.prank(sender, sender);
-            gateway.deposit{value: expectGasUsed + baseCost}(gmpSender, SRC_NETWORK_ID);
-            assertEq(gateway.depositOf(gmpSender, SRC_NETWORK_ID), expectGasUsed + baseCost);
+            // uint256 deposit = baseCost + executionCost + gmpGasLimit + 3440;
+            uint256 deposit = baseCost + executionCost + gmpGasLimit;
+            gateway.deposit{value: deposit}(gmpSender, SRC_NETWORK_ID);
+            assertEq(gateway.depositOf(gmpSender, SRC_NETWORK_ID), deposit);
         }
 
         // Execute GMP message
-        bytes32 expectResult = bytes32(0);
         uint256 beforeBalance = sender.balance;
         CallOptions memory ctx = CallOptions({
             from: sender,
             to: address(gateway),
             value: 0,
-            gasLimit: expectGasUsed + 2160 + 725,
+            gasLimit: baseCost + executionCost + 2160 + 725 + 955,
             executionCost: 0,
             baseCost: 0
         });
         {
             (GmpStatus status, bytes32 returned) = ctx.execute(sig, gmp);
+            assertEq(returned, bytes32(gmpGasLimit), "unexpected GMP result");
 
             // Verify the GMP message status
-            assertTrue(status == GmpStatus.SUCCESS, "Unexpected GMP status");
+            assertEq(uint256(status), uint256(GmpStatus.SUCCESS), "Unexpected GMP status");
             Gateway.GmpInfo memory info = gateway.gmpInfo(gmp.eip712TypedHash(gateway.DOMAIN_SEPARATOR()));
             assertEq(
                 uint256(info.status), uint256(GmpStatus.SUCCESS), "GMP status stored doesn't match the returned status"
             );
-            assertEq(returned, expectResult, "unexpected GMP result");
 
             // Verify the gas cost
-            assertEq(ctx.executionCost, expectGasUsed, "unexpected gas used");
+            assertEq(ctx.executionCost, executionCost + gmpGasLimit, "unexpected gas used");
         }
 
         // Verify the gas refund
         uint256 afterBalance = sender.balance;
-        assertEq(beforeBalance, afterBalance, "wrong refund amount");
+        assertEq(beforeBalance, afterBalance, "wrong refund amount, before != after");
         assertEq(gateway.depositOf(sender.toSender(false), SRC_NETWORK_ID), 0, "discount wrong amount from deposit");
     }
 
     function test_refund() external {
         vm.txGasPrice(1);
-        address sender = TestUtils.createTestAccount(100 ether);
+        GmpSender sender = TestUtils.createTestAccount(100 ether).toSender(false);
 
         // GMP message gas used
         uint256 gmpGasUsed = 1_000;
-        uint256 expectGasUsed = EXECUTE_CALL_COST + gmpGasUsed;
 
         // Build and sign GMP message
         GmpMessage memory gmp = GmpMessage({
-            source: sender.toSender(false),
-            srcNetwork: DEST_NETWORK_ID,
+            source: sender,
+            srcNetwork: SRC_NETWORK_ID,
             dest: address(receiver),
             destNetwork: DEST_NETWORK_ID,
-            gasLimit: 10000,
+            gasLimit: gmpGasUsed,
             salt: 1,
-            data: abi.encodePacked(gmpGasUsed)
+            data: abi.encodePacked(uint256(gmpGasUsed))
         });
         Signature memory sig = sign(gmp);
 
+        // Deposit funds
+        (uint256 baseCost, uint256 executionCost) = GatewayUtils.computeGmpGasCost(sig, gmp);
+        uint256 expectGasUsed = baseCost + executionCost + gmp.gasLimit;
+        uint256 deposit = expectGasUsed * 3;
+        gateway.deposit{value: deposit}(sender, SRC_NETWORK_ID);
+
         // Calculate memory expansion cost and base cost
-        uint256 baseCost;
-        {
-            bytes memory encodedExecuteCall = abi.encodeCall(IExecutor.execute, (sig, gmp));
-            baseCost = TestUtils.calculateBaseCost(encodedExecuteCall);
-            expectGasUsed += TestUtils.memExpansionCost(encodedExecuteCall.length);
-        }
+        // uint256 baseCost;
+        // {
+        //     bytes memory encodedExecuteCall = abi.encodeCall(IExecutor.execute, (sig, gmp));
+        //     baseCost = TestUtils.calculateBaseCost(encodedExecuteCall);
+        //     expectGasUsed += TestUtils.memExpansionCost(encodedExecuteCall.length);
+        // }
 
         // Deposit funds
-        {
-            GmpSender gmpSender = sender.toSender(false);
-            assertEq(gateway.depositOf(gmpSender, DEST_NETWORK_ID), 0);
-            vm.prank(sender, sender);
-            gateway.deposit{value: expectGasUsed + baseCost}(gmpSender, DEST_NETWORK_ID);
-            assertEq(gateway.depositOf(gmpSender, DEST_NETWORK_ID), expectGasUsed + baseCost);
-        }
+        // {
+        //     GmpSender gmpSender = sender.toSender(false);
+        //     assertEq(gateway.depositOf(gmpSender, DEST_NETWORK_ID), 0);
+        //     vm.prank(sender, sender);
+        //     gateway.deposit{value: expectGasUsed + baseCost}(gmpSender, DEST_NETWORK_ID);
+        //     assertEq(gateway.depositOf(gmpSender, DEST_NETWORK_ID), expectGasUsed + baseCost);
+        // }
 
         // Execute GMP message
-        bytes32 expectResult = bytes32(0);
-        uint256 beforeBalance = sender.balance;
+        uint256 beforeBalance = sender.toAddress().balance;
         CallOptions memory ctx = CallOptions({
-            from: sender,
+            from: sender.toAddress(),
             to: address(gateway),
             value: 0,
-            gasLimit: expectGasUsed + 2160 + 785,
+            gasLimit: expectGasUsed + 2160 + 785 + 10,
             executionCost: 0,
             baseCost: 0
         });
@@ -390,22 +387,24 @@ contract GatewayBase is Test {
             (GmpStatus status, bytes32 returned) = ctx.execute(sig, gmp);
 
             // Verify the GMP message status
-            assertTrue(status == GmpStatus.SUCCESS, "Unexpected GMP status");
+            assertEq(uint256(status), uint256(GmpStatus.SUCCESS), "Unexpected GMP status");
             Gateway.GmpInfo memory info = gateway.gmpInfo(gmp.eip712TypedHash(gateway.DOMAIN_SEPARATOR()));
-            assertTrue(info.status == GmpStatus.SUCCESS, "GMP status stored doesn't match the returned status");
-            assertEq(returned, expectResult, "unexpected GMP result");
+            assertEq(
+                uint256(info.status), uint256(GmpStatus.SUCCESS), "GMP status stored doesn't match the returned status"
+            );
+            assertEq(returned, bytes32(gmp.gasLimit), "unexpected GMP result");
 
             // Verify the gas cost
-            assertEq(ctx.executionCost, expectGasUsed, "unexpected gas used");
+            assertEq(ctx.executionCost + ctx.baseCost, expectGasUsed, "unexpected gas used");
         }
 
         // Verify the gas refund
-        uint256 afterBalance = sender.balance;
+        uint256 afterBalance = sender.toAddress().balance;
         assertEq(beforeBalance, afterBalance, "wrong refund amount");
-        assertEq(gateway.depositOf(sender.toSender(false), DEST_NETWORK_ID), 0, "discount wrong amount from deposit");
+        assertEq(gateway.depositOf(sender, DEST_NETWORK_ID), 0, "discount wrong amount from deposit");
     }
 
-    function testExecuteRevertsWrongNetwork() external {
+    function test_ExecuteRevertsWrongNetwork() external {
         vm.txGasPrice(1);
         uint256 amount = 10 ether;
         address sender = TestUtils.createTestAccount(amount * 2);
@@ -425,7 +424,7 @@ contract GatewayBase is Test {
             from: sender,
             to: address(gateway),
             value: 0,
-            gasLimit: EXECUTE_CALL_COST + 10_000,
+            gasLimit: 1_000_000,
             executionCost: 0,
             baseCost: 0
         });
@@ -433,11 +432,11 @@ contract GatewayBase is Test {
         ctx.execute(wrongNetworkSig, wrongNetwork);
     }
 
-    function testExecuteRevertsWrongSource() external {
+    function test_wrongSource() external {
         vm.txGasPrice(1);
         GmpSender sender = TestUtils.createTestAccount(100 ether).toSender(false);
         gateway.deposit{value: 10 ether}(sender, SRC_NETWORK_ID);
-        GmpMessage memory wrongSource = GmpMessage({
+        GmpMessage memory gmp = GmpMessage({
             source: GmpSender.wrap(0x0),
             srcNetwork: SRC_NETWORK_ID,
             dest: address(0),
@@ -446,23 +445,31 @@ contract GatewayBase is Test {
             salt: 1,
             data: ""
         });
-        Signature memory wrongSourceSig = sign(wrongSource);
+        Signature memory sig = sign(gmp);
+
+        // Deposit funds
+        (uint256 baseCost, uint256 executionCost) = GatewayUtils.computeGmpGasCost(sig, gmp);
+        uint256 deposit = (baseCost + executionCost + gmp.gasLimit) * 3;
+        gateway.deposit{value: deposit}(sender, SRC_NETWORK_ID);
+
         CallOptions memory ctx = CallOptions({
             from: sender.toAddress(),
             to: address(gateway),
             value: 0,
-            gasLimit: EXECUTE_CALL_COST + 10_000,
+            gasLimit: baseCost + executionCost + gmp.gasLimit + 100_000,
             executionCost: 0,
             baseCost: 0
         });
-        vm.expectRevert("deposit below max refund");
-        ctx.execute(wrongSourceSig, wrongSource);
+        (GmpStatus status, bytes32 result) = ctx.execute(sig, gmp);
+        assertEq(uint256(status), uint256(GmpStatus.INSUFFICIENT_FUNDS), "unexpected GMP status");
+        assertEq(result, bytes32(0), "unexpected GMP result");
     }
 
-    function testExecuteRevertsWithoutDeposit() external {
+    function test_gmpStatusFailedWithoutDeposit() external {
         vm.txGasPrice(1);
         GmpSender sender = TestUtils.createTestAccount(100 ether).toSender(false);
         assertEq(gateway.depositOf(sender, SRC_NETWORK_ID), 0);
+
         GmpMessage memory gmp = GmpMessage({
             source: sender,
             srcNetwork: SRC_NETWORK_ID,
@@ -473,6 +480,8 @@ contract GatewayBase is Test {
             data: abi.encode(uint256(1_000_000))
         });
         Signature memory sig = sign(gmp);
+
+        // execute gmp message
         CallOptions memory ctx = CallOptions({
             from: sender.toAddress(),
             to: address(gateway),
@@ -481,69 +490,15 @@ contract GatewayBase is Test {
             executionCost: 0,
             baseCost: 0
         });
-        vm.expectRevert("deposit below max refund");
-        ctx.execute(sig, gmp);
+        (GmpStatus status, bytes32 result) = ctx.execute(sig, gmp);
+        assertEq(uint256(status), uint256(GmpStatus.INSUFFICIENT_FUNDS), "unexpected GMP status");
+        assertEq(result, bytes32(0), "unexpected GMP result");
     }
 
-    function testExecuteRevertsBelowDeposit() external {
+    function test_executeRevertsBelowDeposit() external {
         vm.txGasPrice(1);
-        uint256 insufficientDeposit = EXECUTE_CALL_COST - 1;
         GmpSender sender = TestUtils.createTestAccount(100 ether).toSender(false);
-        gateway.deposit{value: insufficientDeposit}(sender, SRC_NETWORK_ID);
-        GmpMessage memory gmp = GmpMessage({
-            source: sender,
-            srcNetwork: SRC_NETWORK_ID,
-            dest: address(receiver),
-            destNetwork: DEST_NETWORK_ID,
-            gasLimit: 10000,
-            salt: 1,
-            data: abi.encode(uint256(10_000))
-        });
-        Signature memory sig = sign(gmp);
-        CallOptions memory ctx = CallOptions({
-            from: sender.toAddress(),
-            to: address(gateway),
-            value: 0,
-            gasLimit: 100_000,
-            executionCost: 0,
-            baseCost: 0
-        });
-        vm.expectRevert("deposit below max refund");
-        ctx.execute(sig, gmp);
-    }
 
-    function testExecuteRevertsBelowGasLimit() external {
-        vm.txGasPrice(1);
-        uint256 gasLimit = 100000;
-        uint256 insufficientDeposit = gasLimit * tx.gasprice;
-        GmpSender sender = TestUtils.createTestAccount(100 ether).toSender(false);
-        gateway.deposit{value: insufficientDeposit}(sender, SRC_NETWORK_ID);
-        GmpMessage memory gmp = GmpMessage({
-            source: sender,
-            srcNetwork: SRC_NETWORK_ID,
-            dest: address(receiver),
-            destNetwork: DEST_NETWORK_ID,
-            gasLimit: gasLimit,
-            salt: 1,
-            data: abi.encode(uint256(100_000))
-        });
-        Signature memory sig = sign(gmp);
-        CallOptions memory ctx = CallOptions({
-            from: sender.toAddress(),
-            to: address(gateway),
-            value: 0,
-            gasLimit: 100_000,
-            executionCost: 0,
-            baseCost: 0
-        });
-        vm.expectRevert("gas left below message.gasLimit");
-        ctx.execute(sig, gmp);
-    }
-
-    function testExecuteRevertsAlreadyExecuted() external {
-        vm.txGasPrice(1);
-        GmpSender sender = TestUtils.createTestAccount(1000 ether).toSender(false);
-        gateway.deposit{value: 100 ether}(sender, SRC_NETWORK_ID);
         GmpMessage memory gmp = GmpMessage({
             source: sender,
             srcNetwork: SRC_NETWORK_ID,
@@ -551,9 +506,83 @@ contract GatewayBase is Test {
             destNetwork: DEST_NETWORK_ID,
             gasLimit: 1000,
             salt: 1,
-            data: abi.encode(uint256(992))
+            data: abi.encode(uint256(10_000))
         });
         Signature memory sig = sign(gmp);
+
+        // Deposit funds
+        (uint256 baseCost, uint256 executionCost) = GatewayUtils.computeGmpGasCost(sig, gmp);
+        uint256 insufficientDeposit = baseCost + executionCost + gmp.gasLimit - 1;
+        gateway.deposit{value: insufficientDeposit}(sender, SRC_NETWORK_ID);
+
+        // Execute GMP message
+        CallOptions memory ctx = CallOptions({
+            from: sender.toAddress(),
+            to: address(gateway),
+            value: 0,
+            gasLimit: 100_000,
+            executionCost: 0,
+            baseCost: 0
+        });
+        (GmpStatus status, bytes32 result) = ctx.execute(sig, gmp);
+        assertEq(uint256(GmpStatus.INSUFFICIENT_FUNDS), uint256(status), "unexpected GMP status");
+        assertEq(result, bytes32(0), "unexpected GMP result");
+        assertLe(ctx.executionCost, executionCost, "unexpected execution cost");
+        assertEq(ctx.baseCost, baseCost, "unexpected base cost");
+    }
+
+    function test_ExecuteRevertsBelowGasLimit() external {
+        vm.txGasPrice(1);
+        GmpSender sender = TestUtils.createTestAccount(100 ether).toSender(false);
+        GmpMessage memory gmp = GmpMessage({
+            source: sender,
+            srcNetwork: SRC_NETWORK_ID,
+            dest: address(receiver),
+            destNetwork: DEST_NETWORK_ID,
+            gasLimit: 100_000,
+            salt: 1,
+            data: abi.encode(uint256(100_000))
+        });
+        Signature memory sig = sign(gmp);
+
+        // Deposit funds
+        (uint256 baseCost, uint256 executionCost) = GatewayUtils.computeGmpGasCost(sig, gmp);
+        uint256 deposit = (baseCost + executionCost + gmp.gasLimit) * 2;
+        gateway.deposit{value: deposit}(sender, SRC_NETWORK_ID);
+
+        // Execute GMP message
+        CallOptions memory ctx = CallOptions({
+            from: sender.toAddress(),
+            to: address(gateway),
+            value: 0,
+            gasLimit: baseCost + executionCost,
+            executionCost: 0,
+            baseCost: 0
+        });
+        vm.expectRevert("insufficient gas to execute GMP message");
+        ctx.execute(sig, gmp);
+    }
+
+    function test_executeRevertsAlreadyExecuted() external {
+        vm.txGasPrice(1);
+        GmpSender sender = TestUtils.createTestAccount(1000 ether).toSender(false);
+        GmpMessage memory gmp = GmpMessage({
+            source: sender,
+            srcNetwork: SRC_NETWORK_ID,
+            dest: address(receiver),
+            destNetwork: DEST_NETWORK_ID,
+            gasLimit: 1000,
+            salt: 1,
+            data: abi.encode(uint256(1000))
+        });
+        Signature memory sig = sign(gmp);
+
+        // Deposit funds
+        (uint256 baseCost, uint256 executionCost) = GatewayUtils.computeGmpGasCost(sig, gmp);
+        uint256 deposit = (baseCost + executionCost + gmp.gasLimit) * 3;
+        gateway.deposit{value: deposit}(sender, SRC_NETWORK_ID);
+
+        // Execute GMP message first time
         CallOptions memory ctx = CallOptions({
             from: sender.toAddress(),
             to: address(gateway),
@@ -562,8 +591,11 @@ contract GatewayBase is Test {
             executionCost: 0,
             baseCost: 0
         });
-        (GmpStatus status,) = ctx.execute(sig, gmp);
-        assertTrue(status == GmpStatus.SUCCESS, "unexpected GMP status");
+        (GmpStatus status, bytes32 result) = ctx.execute(sig, gmp);
+        assertEq(uint256(status), uint256(GmpStatus.SUCCESS), "unexpected GMP status");
+        assertEq(gmp.gasLimit, uint256(result), "unexpected GMP result");
+
+        // Execute GMP message second time
         vm.expectRevert("message already executed");
         ctx.execute(sig, gmp);
     }

--- a/test/Gateway.t.sol
+++ b/test/Gateway.t.sol
@@ -107,8 +107,8 @@ contract GatewayBase is Test {
     // Receiver Contract, the will waste the exact amount of gas you sent to it in the data field
     IGmpReceiver internal receiver;
 
-    uint256 private constant EXECUTE_CALL_COST = 49_662;
-    uint256 private constant SUBMIT_GAS_COST = 5993;
+    uint256 private constant EXECUTE_CALL_COST = 49_670;
+    uint256 private constant SUBMIT_GAS_COST = 6001;
     uint16 private constant SRC_NETWORK_ID = 1234;
     uint16 internal constant DEST_NETWORK_ID = 1337;
     uint8 private constant GMP_STATUS_SUCCESS = 1;
@@ -140,7 +140,7 @@ contract GatewayBase is Test {
         // See the file `HelperContract.opcode` for more details.
         {
             bytes memory bytecode =
-                hex"603b80600a5f395ff3fe60a4355a5b6000828203126004570360080180603b015b805a11601657505a03604b03565b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b00";
+                hex"603b80600c6000396000f3fe60a4355a5b6000828203126004570360080180603b015b805a11601657505a03604b03565b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b00";
             receiver = IGmpReceiver(TestUtils.deployContract(bytecode));
         }
     }

--- a/test/GmpTestTools.sol
+++ b/test/GmpTestTools.sol
@@ -51,7 +51,7 @@ library GmpTestTools {
      * @dev Minimal Eip1667 proxy bytecode.
      */
     bytes private constant _PROXY_BYTECODE =
-        hex"365f5f375f5f365f7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc545af43d5f5f3e6036573d5ffd5b3d5ff3";
+        hex"363d3d373d3d3d363d7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc545af43d82803e903d91603857fd5bf3";
 
     /**
      * @dev Storage slot with the address of the current implementation.

--- a/test/TestUtils.sol
+++ b/test/TestUtils.sol
@@ -92,7 +92,7 @@ library TestUtils {
                 let v := mload(ptr)
                 {
                     let padding := sub(end, ptr)
-                    padding := mul(lt(padding, 256), padding)
+                    padding := mul(lt(padding, 32), padding)
                     v := shr(padding, v)
                 }
 


### PR DESCRIPTION
- [x] Supports `paris` and `shangai` hardforks (before it was only working with Cancun hardfork)
- [x] Check the user deposit BEFORE execute the GMP message
- [x] Doesn't revert when the user doesn't provide deposit, instead set `GmpStatus.INSUFFICIENT_FUNDS`
- [x] Adds a temporary sudo account for update the gateway contract
- [x] Accurately calculate the transaction base cost and execution cost inside the gateway contract.