### PR TITLE
Refactor: Move Gas Spender to another file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "lib/universal-factory"]
 	path = lib/universal-factory
 	url = https://github.com/Analog-Labs/universal-factory
+[submodule "lib/evm-interpreter"]
+	path = lib/evm-interpreter
+	url = https://github.com/Analog-Labs/evm-interpreter

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,7 +3,6 @@ src = "src"
 test = "test"
 out = "out"
 libs = ["lib"]
-match_contract = ".+Test"
 # Permissions
 fs_permissions = [{ access = "read", path = "./lib/universal-factory/abi" }]
 

--- a/remappings.txt
+++ b/remappings.txt
@@ -5,3 +5,4 @@ ds-test/=lib/solmate/lib/ds-test/src/
 @analog-gmp/=src/
 @analog-gmp-testing/=test/
 @universal-factory/=lib/universal-factory/src
+@evm-interpreter/=lib/evm-interpreter/src

--- a/src/utils/GasUtils.sol
+++ b/src/utils/GasUtils.sol
@@ -15,7 +15,7 @@ library GasUtils {
     /**
      * @dev How much gas is used until the first `gasleft()` instruction is executed.
      */
-    uint256 internal constant EXECUTION_SELECTOR_OVERHEAD = 429 + 67 - 22;
+    uint256 internal constant EXECUTION_SELECTOR_OVERHEAD = 474;
 
     /**
      * @dev Base cost of the `IExecutor.execute` method.

--- a/test/GasUtils.t.sol
+++ b/test/GasUtils.t.sol
@@ -7,6 +7,7 @@ import {Signer} from "frost-evm/sol/Signer.sol";
 import {Test, console} from "forge-std/Test.sol";
 import {VmSafe} from "forge-std/Vm.sol";
 import {TestUtils} from "./TestUtils.sol";
+import {GasSpender} from "./utils/GasSpender.sol";
 import {Gateway, GatewayEIP712} from "../src/Gateway.sol";
 import {GatewayProxy} from "../src/GatewayProxy.sol";
 import {GasUtils} from "../src/utils/GasUtils.sol";
@@ -76,13 +77,8 @@ contract GasUtilsBase is Test {
             Gateway(address(TestUtils.setupGateway(deployer, bytes32(uint256(0)), SRC_NETWORK_ID, DEST_NETWORK_ID)));
         vm.deal(address(gateway), 100 ether);
 
-        // Obs: This is a special contract that wastes an exact amount of gas you send to it, helpful for testing GMP refunds and gas limits.
-        // See the file `HelperContract.opcode` for more details.
-        {
-            bytes memory bytecode =
-                hex"603c80600a5f395ff3fe5a600201803d523d60209160643560240135146018575bfd5b60365a116018575a604903565b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5bf3";
-            receiver = IGmpReceiver(TestUtils.deployContract(bytecode));
-        }
+        // Deploy the GasSpender contract, which implements the IGmpReceiver interface.
+        receiver = IGmpReceiver(new GasSpender());
     }
 
     function sign(GmpMessage memory gmp) internal view returns (Signature memory) {

--- a/test/Gateway.t.sol
+++ b/test/Gateway.t.sol
@@ -7,6 +7,7 @@ import {Test, console, Vm} from "forge-std/Test.sol";
 import {VmSafe} from "forge-std/Vm.sol";
 import {TestUtils, SigningKey, SigningUtils} from "./TestUtils.sol";
 import {GasSpender} from "./utils/GasSpender.sol";
+import {BaseTest} from "./utils/BaseTest.sol";
 import {Gateway, GatewayEIP712} from "../src/Gateway.sol";
 import {GatewayProxy} from "../src/GatewayProxy.sol";
 import {GasUtils} from "../src/utils/GasUtils.sol";
@@ -135,7 +136,8 @@ library GatewayUtils {
     }
 }
 
-contract GatewayBase is Test {
+// contract GatewayBase is Test {
+contract GatewayTest is BaseTest {
     using PrimitiveUtils for UpdateKeysMessage;
     using PrimitiveUtils for GmpMessage;
     using PrimitiveUtils for GmpSender;
@@ -753,103 +755,5 @@ contract GatewayBase is Test {
         );
         assertEq(ctx.submitMessage(gmp), id, "unexpected GMP id");
         assertEq(ctx.executionCost, expectedCost - 6800, "unexpected execution gas cost in second call");
-    }
-}
-
-/**
- * @dev Workaround to fix Forge gas report.
- *
- * Due to limitations in forge, the gas cost reported is misleading:
- * - https://github.com/foundry-rs/foundry/issues/6578
- * - https://github.com/foundry-rs/foundry/issues/6910
- *
- * This contract is a workaround that fixes it by inject an arbitrary code into the `GatewayBase`,
- * it replaces the constant `0x7E7E7E7E7E7E...` defined in the `_call` function by the `INLINE_BYTECODE`.
- * This allow us to precisely compute the execution gas cost.
- *
- * This workaround is necessary while solidity doesn't add support to verbatim in inline assembly code.
- * - https://github.com/ethereum/solidity/issues/12067
- *
- * @author Lohann Ferreira
- */
-contract GatewayTest is GatewayBase {
-    /**
-     * @dev Bytecode that does an acurrate gas measurement of a call, it is equivalent to:
-     * ```solidity
-     * uint256 gasBefore = gasleft();
-     * contract.call{gas: gasLimit}(data);
-     * uint256 gasAfter = gasleft();
-     * uint256 gasUsed = gasBefore - gasAfter - OVERHEAD;
-     * assembly {
-     *    mstore(mload(0x40), gasUsed)
-     * }
-     * ```
-     * Solidity is a black box, is not possible to reliably calculate the `OVERHEAD` cost, creating a lot of
-     * uncertainty in the gas measurements. `Yul` have the same issue once we don't control the EVM stack.
-     * This code workaround this by doing the gas measurement right before and after execute the CALL opcode.
-     */
-    // bytes32 private constant INLINE_BYTECODE = 0x670000000000000000813f50919594939291905a96f15a606901909103600052;
-    bytes32 private constant INLINE_BYTECODE = 0x6000823f505a96949290959391f15a607b019091036800000000000000000052;
-
-    constructor() payable {
-        // In solidity the child's constructor are executed before the parent's constructor,
-        // so once this contract extends `GatewayBase`, it's constructor is executed first.
-
-        // Copy `GatewayBase` runtime code into memory.
-        bytes memory runtimeCode = type(GatewayBase).runtimeCode;
-
-        // Replaces the first occurence of `0x7E7E..` in the runtime code by the `INLINE_BYTECODE`
-        assembly ("memory-safe") {
-            let size := mload(runtimeCode)
-            let i := add(runtimeCode, 32)
-
-            // Efficient Algorithm to find 32 consecutive repeated bytes in a byte sequence
-            for {
-                let chunk := 1
-                let end := add(i, size)
-            } gt(chunk, 0) { i := add(i, chunk) } {
-                // Transform all `0x7E` bytes into `0xFF`
-                // 0x81 ^ 0x7E == 0xFF
-                // Also transform all other bytes in something different than `0xFF`
-                chunk := xor(mload(i), 0x8181818181818181818181818181818181818181818181818181818181818181)
-
-                // Find the right most unset bit, which is equivalent to find the
-                // right most byte different than `0x7E`.
-                // ex: (0x12345678FFFFFF + 1) & (~0x12345678FFFFFF) == 0x00000001000000
-                chunk := and(add(chunk, 1), not(chunk))
-
-                // Round down to the closest multiple of 256
-                // Ex: 2 ** 18 become 2 ** 16
-                chunk := div(chunk, mod(chunk, 0xff))
-
-                // Find the number of leading bytes different than `0x7E`.
-                // Rationale:
-                // Multiplying a number by a power of 2 is the same as shifting the bits to the left
-                // 1337 * (2 ** 16) == 1337 << 16
-                // Once the chunk is a multiple of 256 it always shift entire bytes, we use this to
-                // select a specific byte in a byte sequence.
-                chunk := shr(248, mul(0x201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201, chunk))
-
-                // Stop the loop if we go out of bounds
-                chunk := mul(chunk, lt(i, end))
-            }
-
-            // Check if we found the 32 byte constant `7E7E7E...`
-            if not(xor(mload(i), 0x8181818181818181818181818181818181818181818181818181818181818181)) {
-                let ptr := mload(0x40)
-                mstore(ptr, shl(224, 0x08c379a0))
-                mstore(add(ptr, 4), 32) // message offset
-                mstore(add(ptr, 36), 29) // message size
-                mstore(add(ptr, 68), "Failed to inject the bytecode")
-                revert(ptr, 100)
-            }
-
-            // Replace the runtime code with the injected bytecode
-            mstore(add(i, 1), 0x5B)
-            mstore(i, INLINE_BYTECODE)
-
-            // Return the modified runtime code
-            return(add(runtimeCode, 32), mload(runtimeCode))
-        }
     }
 }

--- a/test/GatewayProxy.t.sol
+++ b/test/GatewayProxy.t.sol
@@ -8,6 +8,7 @@ import {FactoryUtils} from "@universal-factory/FactoryUtils.sol";
 import {Test, console} from "forge-std/Test.sol";
 import {VmSafe} from "forge-std/Vm.sol";
 import {TestUtils, SigningKey, SigningUtils} from "./TestUtils.sol";
+import {GasSpender} from "./utils/GasSpender.sol";
 import {Gateway, GatewayEIP712} from "../src/Gateway.sol";
 import {GatewayProxy} from "../src/GatewayProxy.sol";
 import {GasUtils} from "../src/utils/GasUtils.sol";
@@ -51,23 +52,16 @@ contract GatewayProxyTest is Test {
     uint16 private constant SRC_NETWORK_ID = 1234;
     uint16 private constant DEST_NETWORK_ID = 1337;
 
-    // /**
-    //  * @dev The `GatewayProxy` contract admin.
-    //  */
-    // address private constant ADMIN = 0x6f4c950442e1Af093BcfF730381E63Ae9171b87a;
-
     /**
-     * @dev his is a special contract that wastes an exact amount of gas you send to it, helpful for testing GMP refunds and gas limits.
-     * See the file `HelperContract.opcode` for more details.
+     * @dev his is a special contract that implements the IGmpReceiver interface and wastes an exact amount of gas you send to it, helpful
+     * for testing GMP refunds and gas limits.
+     * See the file `GasSpender` contract for more details.
      */
-    bytes private constant RECEIVER_BYTECODE =
-        hex"603c80600a5f395ff3fe5a600201803d523d60209160643560240135146018575bfd5b60365a116018575a604903565b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5bf3";
-
-    // Receiver Contract, the will waste the exact amount of gas you sent to it in the data field
     IGmpReceiver internal receiver;
 
     constructor() {
         require(FACTORY == TestUtils.deployFactory(), "factory address mismatch");
+        receiver = IGmpReceiver(new GasSpender());
     }
 
     function setUp() external view {

--- a/test/utils/BaseTest.sol
+++ b/test/utils/BaseTest.sol
@@ -81,7 +81,9 @@ abstract contract BaseTest is Test {
                 mstore(add(offset, 1), 0x5B)
                 mstore(offset, INLINE_BYTECODE)
 
-                for {} lt(offset, size) {} {
+                // Replace remaining occurences of `0x7E7E7E...` by the `INLINE_BYTECODE`
+
+                for { let end := add(size, 0x20) } lt(offset, end) {} {
                     let backup := mload(offset)
                     mstore(offset, tag)
                     success := staticcall(gas(), findBytes, offset, sub(add(size, 0x20), offset), 0x00, 0x20)
@@ -90,7 +92,6 @@ abstract contract BaseTest is Test {
                     offset := add(mload(0x00), 0x20)
                     mstore(add(offset, 1), 0x5B)
                     mstore(offset, INLINE_BYTECODE)
-                    break
                 }
 
                 return(0x20, size)

--- a/test/utils/BaseTest.sol
+++ b/test/utils/BaseTest.sol
@@ -12,19 +12,43 @@ import {VmSafe} from "forge-std/Vm.sol";
 abstract contract BaseTest is Test {
     using FactoryUtils for IUniversalFactory;
 
-    IUniversalFactory private constant FACTORY = IUniversalFactory(0x0000000000001C4Bf962dF86e38F0c10c7972C6E);
-    address private constant EVM_INTERPRETER = 0x0000000000001e3F4F615cd5e20c681Cf7d85e8D;
-    bytes32 private constant CREATE2_SALT = bytes32(uint256(1234));
-    bytes32 private constant INLINE_BYTECODE = 0x6000823f505a96949290959391f15a607b019091036800000000000000000052;
+    /**
+     * @dev Universal Factory used to deploy contracts at deterministic addresses.
+     * see: https://github.com/Analog-Labs/Universal-factory
+     */
+    IUniversalFactory internal constant FACTORY = IUniversalFactory(0x0000000000001C4Bf962dF86e38F0c10c7972C6E);
 
     /**
-     * @dev The address of the `UniversalFactory` contract, must be the same on all networks.
+     * @dev EVM Interpreter, used to extract the `type(Gateway).runtimeCode` from the `type(Gateway).creationCode`.
+     * see: https://github.com/analog-Labs/evm-interpreter
+     */
+    address internal constant EVM_INTERPRETER = 0x0000000000001e3F4F615cd5e20c681Cf7d85e8D;
+
+    /**
+     * @dev CREATE2 Salt used to deploy the `findBytes` contracts at deterministic addresses.
+     */
+    bytes32 private constant CREATE2_SALT = bytes32(uint256(1234));
+
+    /**
+     * @dev Address who must deploy the `UniversalFactory` contract, to guarantee the same address on all networks.
      */
     address internal constant FACTORY_DEPLOYER = 0x908064dE91a32edaC91393FEc3308E6624b85941;
 
+    /**
+     * @dev The `findBytes` contract bytecode, used to find byte sequences in a given bytecode.
+     */
     bytes private constant FIND_BYTES =
         hex"602e80600a5f395ff3fe60403610602a573d35601f5b6001018035821881361102600b576020813614602a5790033d5260203df35b3d3dfd";
+
+    /**
+     * @dev CODEHASH from the `findBytes` contract bytecode, used to compute the final CREATE2 address..
+     */
     bytes32 private constant FIND_BYTES_CODEHASH = keccak256(FIND_BYTES);
+
+    /**
+     * @dev All byte32 sequences in the form `0x7E7E7E7E7E7E...` will be replaced by the `INLINE_BYTECODE`.
+     */
+    bytes32 private constant INLINE_BYTECODE = 0x6000823f505a96949290959391f15a607b019091036800000000000000000052;
 
     constructor() {
         // Initialize the Universal Factory

--- a/test/utils/BaseTest.sol
+++ b/test/utils/BaseTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Analog's Contracts (last updated v0.1.0) (test/utils/BaseContract.sol)
+// Analog's Contracts (last updated v0.1.0) (test/utils/BaseTest.sol)
 
 pragma solidity >=0.8.0;
 

--- a/test/utils/BaseTest.sol
+++ b/test/utils/BaseTest.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+// Analog's Contracts (last updated v0.1.0) (test/utils/BaseContract.sol)
+
+pragma solidity >=0.8.0;
+
+import {IUniversalFactory} from "@universal-factory/IUniversalFactory.sol";
+import {FactoryUtils} from "@universal-factory/FactoryUtils.sol";
+import {Interpreter} from "@evm-interpreter/Interpreter.sol";
+import {Test, console, Vm} from "forge-std/Test.sol";
+import {VmSafe} from "forge-std/Vm.sol";
+
+abstract contract BaseTest is Test {
+    using FactoryUtils for IUniversalFactory;
+
+    IUniversalFactory private constant FACTORY = IUniversalFactory(0x0000000000001C4Bf962dF86e38F0c10c7972C6E);
+    address private constant EVM_INTERPRETER = 0x0000000000001e3F4F615cd5e20c681Cf7d85e8D;
+    bytes32 private constant CREATE2_SALT = bytes32(uint256(1234));
+    bytes32 private constant INLINE_BYTECODE = 0x6000823f505a96949290959391f15a607b019091036800000000000000000052;
+
+    /**
+     * @dev The address of the `UniversalFactory` contract, must be the same on all networks.
+     */
+    address internal constant FACTORY_DEPLOYER = 0x908064dE91a32edaC91393FEc3308E6624b85941;
+
+    bytes private constant FIND_BYTES =
+        hex"602e80600a5f395ff3fe60403610602a573d35601f5b6001018035821881361102600b576020813614602a5790033d5260203df35b3d3dfd";
+    bytes32 private constant FIND_BYTES_CODEHASH = keccak256(FIND_BYTES);
+
+    constructor() {
+        // Initialize the Universal Factory
+        if (address(FACTORY).code.length == 0) {
+            bytes memory creationCode = vm.getCode("./lib/universal-factory/abi/UniversalFactory.json");
+            vm.deal(FACTORY_DEPLOYER, 100 ether);
+            vm.prank(FACTORY_DEPLOYER, FACTORY_DEPLOYER);
+            address factory;
+            assembly {
+                factory := create(0, add(creationCode, 32), mload(creationCode))
+            }
+            require(factory == address(FACTORY), "Factory address mismatch");
+        }
+
+        // Initialize the EVM Interpreter
+        if (EVM_INTERPRETER.code.length == 0) {
+            bytes memory creationCode = vm.getCode("Interpreter.sol");
+            address interpreter;
+            assembly {
+                interpreter := create(0, add(creationCode, 32), mload(creationCode))
+            }
+            assertTrue(interpreter != address(0), "interpreter creation failed");
+            assertGt(interpreter.code.length, 0, "interpreter code length mismatch");
+            vm.etch(EVM_INTERPRETER, interpreter.code);
+        }
+
+        // Deploy the find bytes contract
+        address findBytes = FACTORY.computeCreate2Address(CREATE2_SALT, FIND_BYTES_CODEHASH);
+
+        // Initialize using the EVM interpreter
+        if (findBytes.code.length == 0) {
+            assertEq(FACTORY.create2(CREATE2_SALT, FIND_BYTES), findBytes, "find bytes creation failed");
+            assembly {
+                // Copy code to memory
+                codecopy(0, 0, codesize())
+
+                // Execute constructor using the EVM interpreter
+                let success := delegatecall(gas(), EVM_INTERPRETER, 0, add(codesize(), 0x20), 0, 0)
+
+                // Copy result to memory
+                returndatacopy(0x20, 0, returndatasize())
+                if iszero(success) { revert(0x20, returndatasize()) }
+
+                // COPY TAG to memory
+                let tag := mul(0x7E, 0x0101010101010101010101010101010101010101010101010101010101010101)
+                mstore(0x00, tag)
+
+                // Find the `0x7E7E7E...` tag in the bytecode
+                let size := returndatasize()
+                if iszero(staticcall(gas(), findBytes, 0x00, add(size, 0x20), 0x00, 0x20)) { revert(0, 0) }
+
+                // Replace the `0x7E7E7E...` by the `INLINE_BYTECODE`
+                let offset := add(mload(0x00), 0x20)
+                mstore(add(offset, 1), 0x5B)
+                mstore(offset, INLINE_BYTECODE)
+
+                for {} lt(offset, size) {} {
+                    let backup := mload(offset)
+                    mstore(offset, tag)
+                    success := staticcall(gas(), findBytes, offset, sub(add(size, 0x20), offset), 0x00, 0x20)
+                    mstore(offset, backup)
+                    if iszero(success) { break }
+                    offset := add(mload(0x00), 0x20)
+                    mstore(add(offset, 1), 0x5B)
+                    mstore(offset, INLINE_BYTECODE)
+                    break
+                }
+
+                return(0x20, size)
+            }
+        }
+    }
+}

--- a/test/utils/GasSpender.sol
+++ b/test/utils/GasSpender.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+// Analog's Contracts (last updated v0.1.0) (test/utils/GasSpender.sol)
+
+pragma solidity >=0.8.0;
+
+import {IGmpReceiver} from "../../src/interfaces/IGmpReceiver.sol";
+
+contract GasSpender is IGmpReceiver {
+    // Following a contract implements the IGmpReceiver interface and wastes the exact amount of gas you send to it in the payload field.
+    //  OFFSET  OPCODE
+    //    0x00  0x5a      GAS
+    //    0x01  0x6002    PUSH1 0x02
+    //    0x03  0x01      ADD
+    //    0x04  0x80      DUP1
+    //    0x05  0x3d      RETURNDATASIZE
+    //    0x06  0x52      MSTORE
+    //    0x07  0x3d      RETURNDATASIZE
+    //    0x08  0x6020    PUSH1 0x20
+    //    0x0a  0x91      SWAP2
+    //    0x0b  0x6064    PUSH1 0x64
+    //    0x0d  0x35      CALLDATALOAD -- Load the payload offset from the calldata
+    //    0x0e  0x6024    PUSH1 0x24
+    //    0x10  0x01      ADD
+    //    0x11  0x35      CALLDATALOAD -- Load the gasToWaste from the payload
+    //    0x12  0x14      EQ
+    //    0x13  0x6018    PUSH1 0x18
+    // ,=<0x15  0x57      JUMPI
+    // |  0x16  0x5b      JUMPDEST
+    // |  0x17  0xfd      REVERT       -- Reverts if the gas left is less than the gas to waste.
+    // |=>0x18  0x5b      JUMPDEST     -- Waste 22 gas each on each iteration
+    // |  0x19  0x6036    PUSH1 0x36
+    // |  0x1b  0x5a      GAS
+    // |  0x1c  0x11      GT
+    // |  0x1d  0x6018    PUSH1 0x18
+    // `=<0x1f  0x57      JUMPI
+    //    0x20  0x5a      GAS
+    //    0x21  0x6049    PUSH1 0x49
+    //    0x23  0x03      SUB
+    // ,=<0x24  0x56      JUMP        -- Jumps depending on how much gas is left
+    // |=>0x25  0x5b      JUMPDEST
+    // |=>0x26  0x5b      JUMPDEST
+    // |=>0x27  0x5b      JUMPDEST
+    // |=>0x28  0x5b      JUMPDEST
+    // |=>0x29  0x5b      JUMPDEST
+    // |=>0x2a  0x5b      JUMPDEST
+    // |=>0x2b  0x5b      JUMPDEST
+    // |=>0x2c  0x5b      JUMPDEST
+    // |=>0x2d  0x5b      JUMPDEST
+    // |=>0x2e  0x5b      JUMPDEST
+    // |=>0x2f  0x5b      JUMPDEST
+    // |=>0x30  0x5b      JUMPDEST
+    // |=>0x31  0x5b      JUMPDEST
+    // |=>0x32  0x5b      JUMPDEST
+    // |=>0x33  0x5b      JUMPDEST
+    // |=>0x34  0x5b      JUMPDEST
+    // |=>0x35  0x5b      JUMPDEST
+    // |=>0x36  0x5b      JUMPDEST
+    // |=>0x37  0x5b      JUMPDEST
+    // |=>0x38  0x5b      JUMPDEST
+    // |=>0x39  0x5b      JUMPDEST
+    // `=>0x3a  0x5b      JUMPDEST
+    //    0x3b  0xf3      RETURN
+    bytes private constant BYTECODE =
+        hex"5a600201803d523d60209160643560240135146018575bfd5b60365a116018575a604903565b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5bf3";
+
+    constructor() payable {
+        bytes memory bytecode = BYTECODE;
+        assembly {
+            return(add(bytecode, 0x20), mload(bytecode))
+        }
+    }
+
+    function onGmpReceived(bytes32, uint128, bytes32, bytes calldata payload) external payable returns (bytes32) {
+        unchecked {
+            // OBS: This is just an example on how this contract works, the actual code is implemented directly in
+            // low level EVM, as defined in the `BYTECODE` constant.
+            uint256 initialGas = gasleft() + 2;
+            uint256 gasToWaste = abi.decode(payload, (uint256));
+            require(initialGas > gasToWaste);
+            uint256 finalGas = initialGas - gasToWaste;
+            while (gasleft() > finalGas) {}
+            return bytes32(initialGas);
+        }
+    }
+}

--- a/test/utils/GasSpender.t.sol
+++ b/test/utils/GasSpender.t.sol
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: MIT
+// Analog's Contracts (last updated v0.1.0) (test/Gateway.t.sol)
+
+pragma solidity >=0.8.0;
+
+import {Test, console, Vm} from "forge-std/Test.sol";
+import {VmSafe} from "forge-std/Vm.sol";
+import {TestUtils} from "../TestUtils.sol";
+import {GasSpender} from "./GasSpender.sol";
+import {GasUtils} from "../../src/utils/GasUtils.sol";
+import {IGmpReceiver} from "../../src/interfaces/IGmpReceiver.sol";
+
+contract GasSpenderBase is Test {
+    function test_onGmpReceivedWorks(uint16 delta) external {
+        // Guarantee the gas limit is not less than 1000
+        uint256 gasToWaste = 1000 + uint256(delta);
+        vm.txGasPrice(1);
+        
+        // Create the Sender account
+        address sender = TestUtils.createTestAccount(100 ether);
+        
+        // Deploy the GasSpender contract
+        GasSpender spender = new GasSpender();
+
+        // Encode the `IGmpReceiver.onGmpReceived` call
+        bytes memory encodedCall = abi.encodeCall(
+            IGmpReceiver.onGmpReceived,
+            (
+                0x0000000000000000000000000000000000000000000000000000000000000000,
+                1,
+                0x0000000000000000000000000000000000000000000000000000000000000000,
+                abi.encode(gasToWaste)
+            )
+        );
+        uint256 gasLimit = TestUtils.calculateBaseCost(encodedCall) + gasToWaste;
+
+        (uint256 gasUsed,, bytes memory output) =
+            TestUtils.executeCall(sender, address(spender), gasLimit, 0, encodedCall);
+        assertEq(gasUsed, gasToWaste);
+        assertEq(output.length, 32);
+    }
+}
+
+/**
+ * @dev Workaround to fix Forge gas report.
+ *
+ * Due to limitations in forge, the gas cost reported is misleading:
+ * - https://github.com/foundry-rs/foundry/issues/6578
+ * - https://github.com/foundry-rs/foundry/issues/6910
+ *
+ * This contract is a workaround that fixes it by inject an arbitrary code into the `GatewayBase`,
+ * it replaces the constant `0x7E7E7E7E7E7E...` defined in the `_call` function by the `INLINE_BYTECODE`.
+ * This allow us to precisely compute the execution gas cost.
+ *
+ * This workaround is necessary while solidity doesn't add support to verbatim in inline assembly code.
+ * - https://github.com/ethereum/solidity/issues/12067
+ *
+ * @author Lohann Ferreira
+ */
+contract GasSpenderTest is GasSpenderBase {
+    /**
+     * @dev Bytecode that does an acurrate gas measurement of a call, it is equivalent to:
+     * ```solidity
+     * uint256 gasBefore = gasleft();
+     * contract.call{gas: gasLimit}(data);
+     * uint256 gasAfter = gasleft();
+     * uint256 gasUsed = gasBefore - gasAfter - OVERHEAD;
+     * assembly {
+     *    mstore(mload(0x40), gasUsed)
+     * }
+     * ```
+     * Solidity is a black box, is not possible to reliably calculate the `OVERHEAD` cost, creating a lot of
+     * uncertainty in the gas measurements. `Yul` have the same issue once we don't control the EVM stack.
+     * This code workaround this by doing the gas measurement right before and after execute the CALL opcode.
+     */
+    bytes32 private constant INLINE_BYTECODE = 0x6000823f505a96949290959391f15a607b019091036800000000000000000052;
+
+    constructor() payable {
+        // In solidity the child's constructor are executed before the parent's constructor,
+        // so once this contract extends `GatewayBase`, it's constructor is executed first.
+
+        // Copy `GatewayBase` runtime code into memory.
+        bytes memory runtimeCode = type(GasSpenderBase).runtimeCode;
+
+        // Replaces the first occurence of `0x7E7E..` in the runtime code by the `INLINE_BYTECODE`
+        assembly ("memory-safe") {
+            let size := mload(runtimeCode)
+            let i := add(runtimeCode, 32)
+
+            // Efficient Algorithm to find 32 consecutive repeated bytes in a byte sequence
+            for {
+                let chunk := 1
+                let end := add(i, size)
+            } gt(chunk, 0) { i := add(i, chunk) } {
+                // Transform all `0x7E` bytes into `0xFF`
+                // 0x81 ^ 0x7E == 0xFF
+                // Also transform all other bytes in something different than `0xFF`
+                chunk := xor(mload(i), 0x8181818181818181818181818181818181818181818181818181818181818181)
+
+                // Find the right most unset bit, which is equivalent to find the
+                // right most byte different than `0x7E`.
+                // ex: (0x12345678FFFFFF + 1) & (~0x12345678FFFFFF) == 0x00000001000000
+                chunk := and(add(chunk, 1), not(chunk))
+
+                // Round down to the closest multiple of 256
+                // Ex: 2 ** 18 become 2 ** 16
+                chunk := div(chunk, mod(chunk, 0xff))
+
+                // Find the number of leading bytes different than `0x7E`.
+                // Rationale:
+                // Multiplying a number by a power of 2 is the same as shifting the bits to the left
+                // 1337 * (2 ** 16) == 1337 << 16
+                // Once the chunk is a multiple of 256 it always shift entire bytes, we use this to
+                // select a specific byte in a byte sequence.
+                chunk := shr(248, mul(0x201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201, chunk))
+
+                // Stop the loop if we go out of bounds
+                chunk := mul(chunk, lt(i, end))
+            }
+
+            // Check if we found the 32 byte constant `7E7E7E...`
+            if not(xor(mload(i), 0x8181818181818181818181818181818181818181818181818181818181818181)) {
+                let ptr := mload(0x40)
+                mstore(ptr, shl(224, 0x08c379a0))
+                mstore(add(ptr, 4), 32) // message offset
+                mstore(add(ptr, 36), 29) // message size
+                mstore(add(ptr, 68), "Failed to inject the bytecode")
+                revert(ptr, 100)
+            }
+
+            // Replace the runtime code with the injected bytecode
+            mstore(add(i, 1), 0x5B)
+            mstore(i, INLINE_BYTECODE)
+
+            // Return the modified runtime code
+            return(add(runtimeCode, 32), mload(runtimeCode))
+        }
+    }
+}

--- a/test/utils/GasSpender.t.sol
+++ b/test/utils/GasSpender.t.sol
@@ -6,11 +6,12 @@ pragma solidity >=0.8.0;
 import {Test, console, Vm} from "forge-std/Test.sol";
 import {VmSafe} from "forge-std/Vm.sol";
 import {TestUtils} from "../TestUtils.sol";
+import {BaseTest} from "./BaseTest.sol";
 import {GasSpender} from "./GasSpender.sol";
 import {GasUtils} from "../../src/utils/GasUtils.sol";
 import {IGmpReceiver} from "../../src/interfaces/IGmpReceiver.sol";
 
-contract GasSpenderBase is Test {
+contract GasSpenderTest is BaseTest {
     function buildCall(uint256 gasToWaste) private pure returns (uint256 gasLimit, bytes memory encodedCall) {
         // Encode the `IGmpReceiver.onGmpReceived` call
         encodedCall = abi.encodeCall(
@@ -29,10 +30,10 @@ contract GasSpenderBase is Test {
         // Guarantee the gas limit is not less than 1000
         uint256 gasToWaste = 1000 + uint256(delta);
         vm.txGasPrice(1);
-        
+
         // Create the Sender account
         address sender = TestUtils.createTestAccount(100 ether);
-        
+
         // Deploy the GasSpender contract
         GasSpender spender = new GasSpender();
 
@@ -49,10 +50,10 @@ contract GasSpenderBase is Test {
         // Guarantee the gas limit is not less than 1000
         uint256 gasToWaste = 1000 + uint256(delta);
         vm.txGasPrice(1);
-        
+
         // Create the Sender account
         address sender = TestUtils.createTestAccount(100 ether);
-        
+
         // Deploy the GasSpender contract
         GasSpender spender = new GasSpender();
 
@@ -67,10 +68,10 @@ contract GasSpenderBase is Test {
         // Guarantee the gas limit is not less than 1000
         uint256 gasToWaste = 1000 + uint256(delta);
         vm.txGasPrice(1);
-        
+
         // Create the Sender account
         address sender = TestUtils.createTestAccount(100 ether);
-        
+
         // Deploy the GasSpender contract
         GasSpender spender = new GasSpender();
 
@@ -79,102 +80,5 @@ contract GasSpenderBase is Test {
 
         vm.expectRevert();
         TestUtils.executeCall(sender, address(spender), gasLimit - 1, 0, encodedCall);
-    }
-}
-
-/**
- * @dev Workaround to fix Forge gas report.
- *
- * Due to limitations in forge, the gas cost reported is misleading:
- * - https://github.com/foundry-rs/foundry/issues/6578
- * - https://github.com/foundry-rs/foundry/issues/6910
- *
- * This contract is a workaround that fixes it by inject an arbitrary code into the `GatewayBase`,
- * it replaces the constant `0x7E7E7E7E7E7E...` defined in the `_call` function by the `INLINE_BYTECODE`.
- * This allow us to precisely compute the execution gas cost.
- *
- * This workaround is necessary while solidity doesn't add support to verbatim in inline assembly code.
- * - https://github.com/ethereum/solidity/issues/12067
- *
- * @author Lohann Ferreira
- */
-contract GasSpenderTest is GasSpenderBase {
-    /**
-     * @dev Bytecode that does an acurrate gas measurement of a call, it is equivalent to:
-     * ```solidity
-     * uint256 gasBefore = gasleft();
-     * contract.call{gas: gasLimit}(data);
-     * uint256 gasAfter = gasleft();
-     * uint256 gasUsed = gasBefore - gasAfter - OVERHEAD;
-     * assembly {
-     *    mstore(mload(0x40), gasUsed)
-     * }
-     * ```
-     * Solidity is a black box, is not possible to reliably calculate the `OVERHEAD` cost, creating a lot of
-     * uncertainty in the gas measurements. `Yul` have the same issue once we don't control the EVM stack.
-     * This code workaround this by doing the gas measurement right before and after execute the CALL opcode.
-     */
-    bytes32 private constant INLINE_BYTECODE = 0x6000823f505a96949290959391f15a607b019091036800000000000000000052;
-
-    constructor() payable {
-        // In solidity the child's constructor are executed before the parent's constructor,
-        // so once this contract extends `GatewayBase`, it's constructor is executed first.
-
-        // Copy `GatewayBase` runtime code into memory.
-        bytes memory runtimeCode = type(GasSpenderBase).runtimeCode;
-
-        // Replaces the first occurence of `0x7E7E..` in the runtime code by the `INLINE_BYTECODE`
-        assembly ("memory-safe") {
-            let size := mload(runtimeCode)
-            let i := add(runtimeCode, 32)
-
-            // Efficient Algorithm to find 32 consecutive repeated bytes in a byte sequence
-            for {
-                let chunk := 1
-                let end := add(i, size)
-            } gt(chunk, 0) { i := add(i, chunk) } {
-                // Transform all `0x7E` bytes into `0xFF`
-                // 0x81 ^ 0x7E == 0xFF
-                // Also transform all other bytes in something different than `0xFF`
-                chunk := xor(mload(i), 0x8181818181818181818181818181818181818181818181818181818181818181)
-
-                // Find the right most unset bit, which is equivalent to find the
-                // right most byte different than `0x7E`.
-                // ex: (0x12345678FFFFFF + 1) & (~0x12345678FFFFFF) == 0x00000001000000
-                chunk := and(add(chunk, 1), not(chunk))
-
-                // Round down to the closest multiple of 256
-                // Ex: 2 ** 18 become 2 ** 16
-                chunk := div(chunk, mod(chunk, 0xff))
-
-                // Find the number of leading bytes different than `0x7E`.
-                // Rationale:
-                // Multiplying a number by a power of 2 is the same as shifting the bits to the left
-                // 1337 * (2 ** 16) == 1337 << 16
-                // Once the chunk is a multiple of 256 it always shift entire bytes, we use this to
-                // select a specific byte in a byte sequence.
-                chunk := shr(248, mul(0x201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201, chunk))
-
-                // Stop the loop if we go out of bounds
-                chunk := mul(chunk, lt(i, end))
-            }
-
-            // Check if we found the 32 byte constant `7E7E7E...`
-            if not(xor(mload(i), 0x8181818181818181818181818181818181818181818181818181818181818181)) {
-                let ptr := mload(0x40)
-                mstore(ptr, shl(224, 0x08c379a0))
-                mstore(add(ptr, 4), 32) // message offset
-                mstore(add(ptr, 36), 29) // message size
-                mstore(add(ptr, 68), "Failed to inject the bytecode")
-                revert(ptr, 100)
-            }
-
-            // Replace the runtime code with the injected bytecode
-            mstore(add(i, 1), 0x5B)
-            mstore(i, INLINE_BYTECODE)
-
-            // Return the modified runtime code
-            return(add(runtimeCode, 32), mload(runtimeCode))
-        }
     }
 }


### PR DESCRIPTION
Improves **GasSpender** contract documentation, and remove the duplicated inline bytecode from tests.