### PR TITLE
Update Commands to have single shard calls.

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -21,7 +21,7 @@ solc = '0.8.28'
 # - https://ethereumclassic.org/knowledge/history
 evm_version = 'shanghai'
 optimizer = true
-optimizer_runs = 200000
+# optimizer_runs = 200000
 
 ###############
 # EVM options #

--- a/src/Gateway.sol
+++ b/src/Gateway.sol
@@ -548,7 +548,7 @@ contract Gateway is IGateway, IExecutor, IUpgradable, GatewayEIP712 {
     /**
      * @dev Register a single Shards with provided TSS public key.
      */
-    function setShard(TssKey calldata publicKey) public {
+    function setShard(TssKey calldata publicKey) external {
         require(msg.sender == ERC1967.getAdmin(), "unauthorized");
         _setShard(publicKey);
     }
@@ -572,7 +572,7 @@ contract Gateway is IGateway, IExecutor, IUpgradable, GatewayEIP712 {
     /**
      * @dev Revoke a single shard TSS Key.
      */
-    function revokeShard(TssKey calldata publicKey) public {
+    function revokeShard(TssKey calldata publicKey) external {
         require(msg.sender == ERC1967.getAdmin(), "unauthorized");
         _revokeShard(publicKey);
     }

--- a/src/Primitives.sol
+++ b/src/Primitives.sol
@@ -83,7 +83,8 @@ struct UpdateKeysMessage {
  */
 enum Command {
     GMP,
-    SetShards,
+    RegisterShard,
+    UnregisterShard,
     SetRoute
 }
 
@@ -103,7 +104,7 @@ struct InboundMessage {
     uint8 version;
     /// @dev The batch ID
     uint64 batchID;
-    /// @dev 
+    /// @dev
     GatewayOp[] ops;
 }
 

--- a/src/interfaces/IExecutor.sol
+++ b/src/interfaces/IExecutor.sol
@@ -4,7 +4,15 @@
 pragma solidity >=0.8.0;
 
 import {
-    InboundMessage, Signature, GmpMessage, TssKey, GmpStatus, GmpStatus, UpdateKeysMessage, GmpSender, Route
+    InboundMessage,
+    Signature,
+    GmpMessage,
+    TssKey,
+    GmpStatus,
+    GmpStatus,
+    UpdateKeysMessage,
+    GmpSender,
+    Route
 } from "../Primitives.sol";
 
 /**
@@ -22,6 +30,12 @@ interface IExecutor {
     event GmpExecuted(
         bytes32 indexed id, GmpSender indexed source, address indexed dest, GmpStatus status, bytes32 result
     );
+
+    /**
+     * @dev Emitted when a Batch is executed.
+     * @param batch batch_id which is executed
+     */
+    event BatchExecuted(uint64 batch);
 
     /**
      * @dev Emitted when shards are registered.


### PR DESCRIPTION
- Seperate shard calls to process single shard and moved from `setShards` to `register/revoke`
- Extend Command enum to include RegisterShard and UnregisterShard.
- Emit `BatchExecuted` event on executing a batch.