### PR TITLE
Updates rootHash and singingHash to avoid replay attacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ docs/
 
 # MacOS
 **/.DS_Store
+
+# built artifacts
+src/artifacts/

--- a/src/Gateway.sol
+++ b/src/Gateway.sol
@@ -342,7 +342,9 @@ contract Gateway is IGateway, IExecutor, IUpgradable, GatewayEIP712 {
         emit BatchExecuted(message.batchID);
 
         // Compute the Batch signing hash
-        bytes32 signingHash = keccak256(abi.encodePacked("Analog GMP v2", NETWORK_ID, address(this), rootHash));
+        rootHash = Hashing.hash(message.version, message.batchID, uint256(rootHash));
+        bytes32 signingHash =
+            keccak256(abi.encodePacked("Analog GMP v2", NETWORK_ID, bytes32(uint256(uint160(address(this)))), rootHash));
 
         // Verify the signature
         _verifySignature(signature, signingHash);

--- a/test/Batching.t.sol
+++ b/test/Batching.t.sol
@@ -256,9 +256,10 @@ contract Batching is BaseTest {
             }
             rootHash = Hashing.hash(uint256(rootHash), uint256(op.command), uint256(operationHash));
         }
-        // return Hashing.hash(message.version, message.batchID, uint256(messageHash));
-        // TODO: The `message.version` and `message.batchID` must be part of the signing hash.
-        return keccak256(abi.encodePacked("Analog GMP v2", DEST_NETWORK_ID, address(GATEWAY_PROXY), rootHash));
+        rootHash = Hashing.hash(message.version, message.batchID, uint256(rootHash));
+        return keccak256(
+            abi.encodePacked("Analog GMP v2", DEST_NETWORK_ID, bytes32(uint256(uint160(GATEWAY_PROXY))), rootHash)
+        );
     }
 
     function signAt(SigningKey memory signer, InboundMessage memory message, Signature memory sig) private view {


### PR DESCRIPTION
- Adds `BatchId` and `Version` in rootHash calculation.
- Uses gateway address in `bytes32` format while computing signingHash