### PR TITLE
rm wrong storage-location annotation

### DIFF
--- a/src/storage/Shards.sol
+++ b/src/storage/Shards.sol
@@ -76,7 +76,6 @@ library ShardStore {
      * the shard info below 256 bit, so it can be stored in one single storage slot.
      * reference: https://docs.soliditylang.org/en/latest/internals/layout_in_storage.html
      *
-     * @custom:storage-location erc7201:analog.one.gateway.shards
      */
     struct MainStorage {
         EnumerableSet.Map shards;


### PR DESCRIPTION
I had the following compilation error when import analog-gmp to our erc20 token:

```
DuplicateNamespaceError: Namespace erc7201:analog.one.gateway.shards is defined multiple times for contract ShardStore

The namespace erc7201:analog.one.gateway.shards was found in structs at the following locations:
- lib/analog-gmp/src/storage/Shards.sol:67
- lib/analog-gmp/src/storage/Shards.sol:81
```

This PR fixes it.